### PR TITLE
SourceB: send Probe after GrantAck received

### DIFF
--- a/src/main/scala/coupledL2/GrantBufferFIFO.scala
+++ b/src/main/scala/coupledL2/GrantBufferFIFO.scala
@@ -105,7 +105,7 @@ class GrantBufferFIFO(implicit p: Parameters) extends BaseGrantBuffer with HasCi
 
   io.grantStatus zip inflight_grant foreach {
     case (g, i) =>
-      g.unsent := i.valid && !i.bits.sent
+      g.valid := i.valid
       g.tag    := i.bits.tag
       g.set    := i.bits.set
   }
@@ -115,7 +115,6 @@ class GrantBufferFIFO(implicit p: Parameters) extends BaseGrantBuffer with HasCi
     val insertIdx = io.d_task.bits.task.sourceId
     val entry = inflight_grant(insertIdx)
     entry.valid := true.B
-    entry.bits.sent  := false.B
     entry.bits.set   := io.d_task.bits.task.set
     entry.bits.tag   := io.d_task.bits.task.tag
     entry.bits.sink  := io.d_task.bits.task.mshrId
@@ -193,7 +192,6 @@ class GrantBufferFIFO(implicit p: Parameters) extends BaseGrantBuffer with HasCi
       val hasData = io.d.bits.opcode(0)
 
       when (io.d.fire()) {
-        inflight_grant(tasks(idx).sourceId).bits.sent := true.B
         when (hasData) {
           beat_valids(idx) := VecInit(next_beatsOH.asBools)
           // only when all beats fire, inc deqPtrExt

--- a/src/main/scala/coupledL2/MainPipe.scala
+++ b/src/main/scala/coupledL2/MainPipe.scala
@@ -506,7 +506,8 @@ class MainPipe(implicit p: Parameters) extends L2Module {
 
     // allTask false: only !mshrTask (SinkReq) blocks Entrance
     // allTask true : all tasks with the same set at s2 block Entrance
-    // tag true: compare tag+set
+    // tag true : compare tag+set
+    // tag false: compare set alone
     s.set === s1_set && (if(allTask) true.B else !s.mshrTask) && (if(tag) s.tag === s1_tag else true.B)
   }
 


### PR DESCRIPTION
to be fully assured that L1 receives Grant before Probe

It is not enough that L2 sends Grant prior to Probe cuz L2 has multiple banks and but L1 only one, and GrantData may still be delayed in xbar