### PR TITLE
mshr: fix sourceA opcode assignment

### DIFF
--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -132,7 +132,8 @@ class MSHR(implicit p: Parameters) extends L2Module {
     oa.opcode := Mux(
       req_put || req_acquirePerm,
       req.opcode,
-      Mux(dirResult.hit, AcquirePerm, AcquireBlock)
+      // Get or AcquireBlock
+      AcquireBlock
     )
     oa.param := Mux(
       req_put,


### PR DESCRIPTION
* For acquireBlock BtoT, L2 should send acquireBlock downwards instead
* of acquirePerm cuz a probe toN may occur during refill process