### PR TITLE
MSHR: Fix bug when multiple refill_release in mainpipe not block

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -163,9 +163,9 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle {
 
   // to block Acquire for to-be-replaced data until Release done (indicated by ReleaseAck received)
   val needRelease = Bool()
-  // MSHR needs to send ReleaseTask but has not yet sent it
+  // MSHR needs to send ReleaseTask but has not in mainpipe s3, RefillTask in MP need to block
   // PS: ReleaseTask is also responsible for writing refillData to DS when A miss
-  val releaseNotSent = Bool()
+  val blockRefill = Bool()
 
   val metaTag = UInt(tagBits.W)
   val dirHit = Bool()

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -222,7 +222,7 @@ class Directory(implicit p: Parameters) extends L2Module {
   // we cancel the Grant and let it retry
   // TODO: timing?
   val wayConflictMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === req_s3.set && (s.bits.releaseNotSent || s.bits.dirHit) && s.bits.way === finalWay
+    s.valid && s.bits.set === req_s3.set && (s.bits.blockRefill || s.bits.dirHit) && s.bits.way === finalWay
   )).asUInt
   val refillRetry = wayConflictMask.orR
 

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -522,7 +522,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.way := dirResult.way
   io.msInfo.bits.reqTag := req.tag
   io.msInfo.bits.needRelease := !state.w_releaseack
-  io.msInfo.bits.releaseNotSent := releaseNotSent
+  io.msInfo.bits.blockRefill := releaseNotSent || RegNext(releaseNotSent,false.B) || RegNext(RegNext(releaseNotSent,false.B),false.B)
   io.msInfo.bits.dirHit := dirResult.hit
   io.msInfo.bits.metaTag := dirResult.tag
   io.msInfo.bits.willFree := will_free

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -522,6 +522,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.way := dirResult.way
   io.msInfo.bits.reqTag := req.tag
   io.msInfo.bits.needRelease := !state.w_releaseack
+  // if releaseTask is already in mainpipe_s1/s2, while a refillTask in mainpipe_s3, the refill should also be blocked and retry
   io.msInfo.bits.blockRefill := releaseNotSent || RegNext(releaseNotSent,false.B) || RegNext(RegNext(releaseNotSent,false.B),false.B)
   io.msInfo.bits.dirHit := dirResult.hit
   io.msInfo.bits.metaTag := dirResult.tag

--- a/src/main/scala/coupledL2/SinkB.scala
+++ b/src/main/scala/coupledL2/SinkB.scala
@@ -75,7 +75,7 @@ class SinkB(implicit p: Parameters) extends L2Module {
 
   // unable to accept incoming B req because same-addr as some MSHR replaced block and cannot nest
   val replaceConflictMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.releaseNotSent
+    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.blockRefill
   )).asUInt
   val replaceConflict = replaceConflictMask.orR
 

--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -163,7 +163,7 @@ class SinkC(implicit p: Parameters) extends L2Module {
 
   // C-Release writing new data to refillBuffer, for repl-Release to write to DS
   val newdataMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === io.task.bits.set && s.bits.reqTag === io.task.bits.tag && s.bits.releaseNotSent
+    s.valid && s.bits.set === io.task.bits.set && s.bits.reqTag === io.task.bits.tag && s.bits.blockRefill
   )).asUInt
 
   // we must wait until 2nd beat written into databuf(idx) before we can read it


### PR DESCRIPTION
* MSHRInfo: Rename releaseNotSent as blockRefill
* MSHR: Extend 2 cycles for releaseNotSent to block RefillTask in Mainpipe s3 for same cache line