### PR TITLE
Retry wayMask: fix dead lock bug when mshr_refill retry

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -69,6 +69,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle with HasChannelBits {
   val mshrId = UInt(mshrBits.W)           // mshr entry index (used only in mshr-task)
   val aliasTask = aliasBitsOpt.map(_ => Bool()) // Anti-alias
   val useProbeData = Bool()               // data source, true for ReleaseBuf and false for RefillBuf
+  val mshrRetry = Bool()                  // is retry task for mshr conflict
 
   // For Intent
   val fromL2pft = prefetchOpt.map(_ => Bool()) // Is the prefetch req from L2(BOP) or from L1 prefetch?
@@ -209,6 +210,7 @@ class FSMState(implicit p: Parameters) extends L2Bundle {
   val s_refill = Bool()   // respond grant upwards
   // val s_grantack = Bool() // respond grantack downwards, moved to GrantBuf
   // val s_triggerprefetch = prefetchOpt.map(_ => Bool())
+  val s_retry = Bool()    // need retry when conflict
 
   // wait
   val w_rprobeackfirst = Bool()

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -188,10 +188,11 @@ class Directory(implicit p: Parameters) extends L2Module {
   val chosenWay = Mux(inv, invalidWay, replaceWay)
   // if chosenWay not in wayMask, then choose a way in wayMask
   // TODO: consider remove this is not used for better timing
+  // for retry bug fixing: if the chosenway cause retry last time, choose another way
   val finalWay = Mux(
     req_s3.wayMask(chosenWay),
     chosenWay,
-    PriorityEncoder(req_s3.wayMask) // can be optimized
+    PriorityEncoder(req_s3.wayMask)
   )
 
   val hit_s3 = Cat(hitVec).orR

--- a/src/main/scala/coupledL2/GrantBuffer.scala
+++ b/src/main/scala/coupledL2/GrantBuffer.scala
@@ -130,6 +130,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   mergeAtask.mshrId := io.d_task.bits.task.mshrId
   mergeAtask.aliasTask.foreach(_ := io.d_task.bits.task.aliasTask.getOrElse(0.U))
   mergeAtask.useProbeData := false.B
+  mergeAtask.mshrRetry := false.B
   mergeAtask.fromL2pft.foreach(_ := false.B)
   mergeAtask.needHint.foreach(_ := false.B)
   mergeAtask.dirty := io.d_task.bits.task.dirty

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -464,6 +464,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   when (io.replResp.valid && replResp.retry) {
     state.s_refill := false.B
     state.s_retry := false.B
+    dirResult.way := replResp.way
   }
   when (io.replResp.valid && !replResp.retry) {
     state.w_replResp := true.B

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -186,6 +186,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     // mp_release definitely read releaseBuf and refillBuf at ReqArb
     // and it needs to write refillData to DS, so useProbeData is set false according to DS.wdata logic
     mp_release.useProbeData := false.B
+    mp_release.mshrRetry := false.B
     mp_release.way := dirResult.way
     mp_release.fromL2pft.foreach(_ := false.B)
     mp_release.needHint.foreach(_ := false.B)
@@ -230,6 +231,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_probeack.mshrId := io.id
     mp_probeack.aliasTask.foreach(_ := false.B)
     mp_probeack.useProbeData := true.B // write [probeAckData] to DS, if not probed toN
+    mp_probeack.mshrRetry := false.B
     mp_probeack.way := dirResult.way
     mp_probeack.fromL2pft.foreach(_ := false.B)
     mp_probeack.needHint.foreach(_ := false.B)
@@ -342,6 +344,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_grant.needHint.foreach(_ := false.B)
     mp_grant.replTask := !dirResult.hit // Get and Alias are hit that does not need replacement
     mp_grant.wayMask := 0.U(cacheParams.ways.W)
+    mp_grant.mshrRetry := !state.s_retry
     mp_grant.reqSource := 0.U(MemReqSource.reqSourceBits.W)
 
     // Add merge grant task for Acquire and late Prefetch
@@ -405,6 +408,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   when (io.tasks.mainpipe.ready) {
     when (mp_grant_valid) {
       state.s_refill := true.B
+      state.s_retry := true.B
     }.elsewhen (mp_release_valid) {
       state.s_release := true.B
       meta.state := INVALID
@@ -459,6 +463,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   val replResp = io.replResp.bits
   when (io.replResp.valid && replResp.retry) {
     state.s_refill := false.B
+    state.s_retry := false.B
   }
   when (io.replResp.valid && !replResp.retry) {
     state.w_replResp := true.B

--- a/src/main/scala/coupledL2/MainPipe.scala
+++ b/src/main/scala/coupledL2/MainPipe.scala
@@ -214,6 +214,7 @@ class MainPipe(implicit p: Parameters) extends L2Module {
   ms_task.mshrId           := 0.U(mshrBits.W)
   ms_task.aliasTask.foreach(_ := cache_alias)
   ms_task.useProbeData     := false.B
+  ms_task.mshrRetry        := false.B
   ms_task.fromL2pft.foreach(_ := req_s3.fromL2pft.get)
   ms_task.needHint.foreach(_  := req_s3.needHint.get)
   ms_task.dirty            := false.B

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -134,7 +134,9 @@ class RequestArb(implicit p: Parameters) extends L2Module {
   io.dirRead_s1.valid := chnl_task_s1.valid && !mshr_task_s1.valid || s1_needs_replRead && !io.fromMainPipe.blockG_s1
   io.dirRead_s1.bits.set := task_s1.bits.set
   io.dirRead_s1.bits.tag := task_s1.bits.tag
-  io.dirRead_s1.bits.wayMask := Fill(cacheParams.ways, "b1".U) //[deprecated]
+  // invalid way which causes mshr_retry
+  // TODO: random waymask can be used to avoid multi-way conflict
+  io.dirRead_s1.bits.wayMask := Mux(mshr_task_s1.valid && mshr_task_s1.bits.mshrRetry, (~(1.U(cacheParams.ways.W) << mshr_task_s1.bits.way)), Fill(cacheParams.ways, "b1".U))
   io.dirRead_s1.bits.replacerInfo.opcode := task_s1.bits.opcode
   io.dirRead_s1.bits.replacerInfo.channel := task_s1.bits.channel
   io.dirRead_s1.bits.replacerInfo.reqSource := task_s1.bits.reqSource

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -53,6 +53,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.mshrId := 0.U(mshrBits.W)
     task.aliasTask.foreach(_ := false.B)
     task.useProbeData := false.B
+    task.mshrRetry := false.B
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
@@ -87,6 +88,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.mshrId := 0.U(mshrBits.W)
     task.aliasTask.foreach(_ := false.B)
     task.useProbeData := false.B
+    task.mshrRetry := false.B
     task.fromL2pft.foreach(_ := req.isBOP)
     task.needHint.foreach(_ := false.B)
     task.dirty := false.B

--- a/src/main/scala/coupledL2/SinkB.scala
+++ b/src/main/scala/coupledL2/SinkB.scala
@@ -51,6 +51,7 @@ class SinkB(implicit p: Parameters) extends L2Module {
     task.mshrId := 0.U(mshrBits.W)
     task.aliasTask.foreach(_ := false.B)
     task.useProbeData := false.B
+    task.mshrRetry := false.B
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := false.B)
     task.dirty := false.B

--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -86,6 +86,7 @@ class SinkC(implicit p: Parameters) extends L2Module {
     task.mshrId := 0.U(mshrBits.W)
     task.aliasTask.foreach(_ := false.B)
     task.useProbeData := false.B
+    task.mshrRetry := false.B
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := false.B)
     task.dirty := false.B


### PR DESCRIPTION
* mshr: add s_retry to label the mshr_task is retry req for way_conflict
* requestArb: use waymask to mask the conflict way for retry mshr_task
* directory & mainpipe: if mshr_task retry, avoid choose the conflict way last time when dir_read