### PR TITLE
Fix some bugs for CPL2

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -185,6 +185,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle {
   val s_refill = Bool()
   val param = UInt(3.W)
   val mergeA = Bool() // whether the mshr already merge an acquire(avoid alias merge)
+  val w_releaseack = Bool()
 }
 
 class RespInfoBundle(implicit p: Parameters) extends L2Bundle {

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -548,6 +548,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.s_refill := state.s_refill
   io.msInfo.bits.param := req.param
   io.msInfo.bits.mergeA := mergeA
+  io.msInfo.bits.w_releaseack := state.w_releaseack
 
   assert(!(c_resp.valid && !io.status.bits.w_c_resp))
   assert(!(d_resp.valid && !io.status.bits.w_d_resp))

--- a/src/main/scala/coupledL2/MSHR.scala
+++ b/src/main/scala/coupledL2/MSHR.scala
@@ -125,7 +125,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     oa.off := req.off
     oa.source := io.id
     oa.opcode := Mux(
-      req_acquirePerm,
+      req_acquirePerm && dirResult.hit,
       req.opcode,
       // Get or AcquireBlock
       AcquireBlock

--- a/src/main/scala/coupledL2/MainPipe.scala
+++ b/src/main/scala/coupledL2/MainPipe.scala
@@ -178,7 +178,7 @@ class MainPipe(implicit p: Parameters) extends L2Module {
   val need_mshr_s3_a = need_acquire_s3_a || need_probe_s3_a || cache_alias
   // For channel B reqs, alloc mshr when Probe hits in both self and client dir
   val need_mshr_s3_b = dirResult_s3.hit && req_s3.fromB &&
-    !(meta_s3.state === BRANCH && req_s3.param === toB) &&
+    !((meta_s3.state === BRANCH || meta_s3.state === TIP) && req_s3.param === toB) &&
     meta_has_clients_s3
 
   // For channel C reqs, Release will always hit on MainPipe, no need for MSHR

--- a/src/main/scala/coupledL2/SinkB.scala
+++ b/src/main/scala/coupledL2/SinkB.scala
@@ -75,9 +75,9 @@ class SinkB(implicit p: Parameters) extends L2Module {
     s.valid && s.bits.set === task.set && s.bits.reqTag === task.tag && !s.bits.willFree && !s.bits.nestB
   )).asUInt.orR
 
-  // unable to accept incoming B req because same-addr as some MSHR replaced block and cannot nest
+  // unable to accept incoming B req because same-addr Release to L3 and have not received ReleaseAck, and some MSHR replaced block and cannot nest
   val replaceConflictMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.blockRefill
+    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.blockRefill && !s.bits.w_releaseack
   )).asUInt
   val replaceConflict = replaceConflictMask.orR
 

--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -50,10 +50,10 @@ class SinkC(implicit p: Parameters) extends L2Module {
 
   // dataBuf entry is valid when Release has data
   // taskBuf entry is valid when ReqArb is not ready to receive C tasks
-  val dataBuf = Reg(Vec(bufBlocks, Vec(beatSize, UInt((beatBytes * 8).W))))
+  val dataBuf = RegInit(VecInit(Seq.fill(bufBlocks)(VecInit(Seq.fill(beatSize)(0.U.asTypeOf(UInt((beatBytes * 8).W)))))))
   val beatValids = RegInit(VecInit(Seq.fill(bufBlocks)(VecInit(Seq.fill(beatSize)(false.B)))))
   val dataValids = VecInit(beatValids.map(_.asUInt.orR)).asUInt
-  val taskBuf = Reg(Vec(bufBlocks, new TaskBundle))
+  val taskBuf = RegInit(VecInit(Seq.fill(bufBlocks)(0.U.asTypeOf(new TaskBundle))))
   val taskValids = RegInit(VecInit(Seq.fill(bufBlocks)(false.B)))
   val taskArb = Module(new RRArbiter(new TaskBundle, bufBlocks))
   val bufValids = taskValids.asUInt | dataValids


### PR DESCRIPTION
1. SinkB: cannot accept Probe when same-addr Release to L3 and have not receive ReleaseAck
2. MainPipe: when L3_probetoB and L2=TIP, L2 donot need probetoB L1
3. MSHR: fix bug when L1_acquirePerm but L2_miss, L2 should acquireBlock to L3, not only acquirePerm
4. SinkC: fix bug for regs Buf not init