### PR TITLE
configs: use hartid from io

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -80,6 +80,8 @@ trait HasCoupledL2Parameters {
   lazy val msgSizeBits = edgeIn.bundle.sizeBits
   lazy val sourceIdAll = 1 << sourceIdBits
 
+  lazy val hartIdLen: Int = log2Up(cacheParams.hartIds.length)
+
   val mshrsAll = cacheParams.mshrs
   val idsAll = 256// ids of L2 //TODO: Paramterize like this: max(mshrsAll * 2, sourceIdAll * 2)
   val mshrBits = log2Up(idsAll)

--- a/src/main/scala/coupledL2/prefetch/Prefetcher.scala
+++ b/src/main/scala/coupledL2/prefetch/Prefetcher.scala
@@ -172,6 +172,7 @@ class Prefetcher(implicit p: Parameters) extends PrefetchModule {
       bop.io.resp <> io.resp
       tp.io.train <> io.train
       tp.io.resp <> io.resp
+      tp.io.hartid := tpio.tpmeta_port.get.req.bits.hartid
 
       // send to prq
       pftQueue.io.enq.valid := pfRcv.io.req.valid || (l2_pf_en && (bop.io.req.valid || tp.io.req.valid))


### PR DESCRIPTION
Using hartid from parameters will result in the module not being deduplicated by chisel and firrtl. Each hart will produce its module in verilog, making it hard for the rtl simulator to optimize.