### PR TITLE
configs: fix use hartid from io (#102)

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -234,6 +234,7 @@ class CoupledL2(implicit p: Parameters) extends LazyModule with HasCoupledL2Para
     val banks = node.in.size
     val bankBits = if (banks == 1) 0 else log2Up(banks)
     val io = IO(new Bundle {
+      val hartId = Input(UInt(hartIdLen.W))
     //  val l2_hint = Valid(UInt(32.W))
       val l2_hint = ValidIO(new L2ToL1Hint())
       val debugTopDown = new Bundle {
@@ -286,6 +287,7 @@ class CoupledL2(implicit p: Parameters) extends LazyModule with HasCoupledL2Para
       _ =>
         fastArb(prefetchTrains.get, prefetcher.get.io.train, Some("prefetch_train"))
         prefetcher.get.io.req.ready := Cat(prefetchReqsReady).orR
+        prefetcher.get.hartId := io.hartId
         fastArb(prefetchResps.get, prefetcher.get.io.resp, Some("prefetch_resp"))
     }
     pf_recv_node match {

--- a/src/main/scala/coupledL2/prefetch/Prefetcher.scala
+++ b/src/main/scala/coupledL2/prefetch/Prefetcher.scala
@@ -127,6 +127,8 @@ class Prefetcher(implicit p: Parameters) extends PrefetchModule {
   val tpio = IO(new Bundle() {
     val tpmeta_port = prefetchOpt.map(_ => new tpmetaPortIO)
   })
+  val hartId = IO(Input(UInt(hartIdLen.W)))
+
   /* io_l2_pf_en:
    * chicken bits for whether L2 prefetchers are enabled
    * it will control BOP and TP prefetchers
@@ -172,7 +174,7 @@ class Prefetcher(implicit p: Parameters) extends PrefetchModule {
       bop.io.resp <> io.resp
       tp.io.train <> io.train
       tp.io.resp <> io.resp
-      tp.io.hartid := tpio.tpmeta_port.get.req.bits.hartid
+      tp.io.hartid := hartId
 
       // send to prq
       pftQueue.io.enq.valid := pfRcv.io.req.valid || (l2_pf_en && (bop.io.req.valid || tp.io.req.valid))

--- a/src/test/scala/TestTop.scala
+++ b/src/test/scala/TestTop.scala
@@ -77,6 +77,8 @@ class TestTop_L2()(implicit p: Parameters) extends LazyModule {
       case (node, i) =>
         node.makeIOs()(ValName(s"master_port_$i"))
     }
+
+    l2.module.io.hartId := DontCare
   }
 
 }
@@ -136,7 +138,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
         rrTagBits = 6
       ))
     )
-  }))).node
+  })))
 
   val l3 = LazyModule(new HuanCun()(new Config((_, _, _) => {
     case HCCacheParamsKey => HCCacheParameters(
@@ -171,7 +173,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
     TLDelayer(delayFactor) :=*
     l3.node :=*
     TLBuffer() :=
-    l2 :=* xbar
+    l2.node :=* xbar
 
   lazy val module = new LazyModuleImp(this) {
     val timer = WireDefault(0.U(64.W))
@@ -188,6 +190,8 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
       case (node, i) =>
         node.makeIOs()(ValName(s"master_port_$i"))
     }
+
+    l2.module.io.hartId := DontCare // Some other signals also need DontCare
   }
 
 }
@@ -280,6 +284,8 @@ class TestTop_L2_Standalone()(implicit p: Parameters) extends LazyModule {
         node.makeIOs()(ValName(s"master_port_$i"))
     }
     l3.makeIOs()(ValName(s"slave_port"))
+
+    l2.module.io.hartId := DontCare // Some other signals also need DontCare
   }
 
 }
@@ -384,7 +390,13 @@ class TestTop_L2L3L2()(implicit p: Parameters) extends LazyModule {
     dontTouch(clean)
     dontTouch(dump)
 
-    coupledL2.foreach(_.module.io.debugTopDown := DontCare)
+    coupledL2.foreach {
+      case l2 => {
+        l2.module.io.debugTopDown := DontCare
+        l2.module.io.hartId := DontCare
+      }
+    }
+
     master_nodes.zipWithIndex.foreach {
       case (node, i) =>
         node.makeIOs()(ValName(s"master_port_$i"))
@@ -444,7 +456,7 @@ class TestTop_fullSys()(implicit p: Parameters) extends LazyModule {
     master_nodes = master_nodes ++ Seq(l1d, l1i) // TODO
 
     val l1xbar = TLXbar()
-    val l2node = LazyModule(new CoupledL2()(new Config((_, _, _) => {
+    val l2 = LazyModule(new CoupledL2()(new Config((_, _, _) => {
       case L2ParamKey => L2Param(
         name = s"l2$i",
         ways = 4,
@@ -456,12 +468,16 @@ class TestTop_fullSys()(implicit p: Parameters) extends LazyModule {
           rrTagBits = 6
         ))
       )
-    }))).node
+    })))
 
     l1xbar := TLBuffer() := l1i
     l1xbar := TLBuffer() := l1d
 
-    l2xbar := TLBuffer() := l2node := l1xbar
+    l2xbar := TLBuffer() := l2.node := l1xbar
+
+    InModuleBody {
+      l2.module.io.hartId := DontCare // Some other signals also need DontCare
+    }
   }
 
   val l3 = LazyModule(new HuanCun()(new Config((_, _, _) => {


### PR DESCRIPTION
I have written 'tp.io.hartid := tpio.tpmeta_port.get.req.bits.hartid' before in #103. However, it is not the hartid that comes from tile but TemporalPrefetcher and caused a loop in Chisel.Queue, as it doesn't use flow, so we didn't see errors in FIRRTL but we will not get the right hartId. This commit fixes this by adding an io to the CoupledL2 module and using hartId input from the L2Top module. To get this done, we must modify L2Top.scala like this outside this repo.

```diff
diff --git a/src/main/scala/xiangshan/L2Top.scala b/src/main/scala/xiangshan/L2Top.scala
index b4865aba5..07d1668bb 100644
--- a/src/main/scala/xiangshan/L2Top.scala
+++ b/src/main/scala/xiangshan/L2Top.scala
@@ -144,6 +144,7 @@ class L2Top()(implicit p: Parameters) extends LazyModule
     if (l2cache.isDefined) {
       l2_hint := l2cache.get.module.io.l2_hint
       // debugTopDown <> l2cache.get.module.io.debugTopDown
+      l2cache.get.module.io.hartId := hartId.fromTile
       l2cache.get.module.io.debugTopDown.robHeadPaddr := DontCare
       l2cache.get.module.io.debugTopDown.robHeadPaddr.head := debugTopDown.robHeadPaddr
       debugTopDown.l2MissMatch := l2cache.get.module.io.debugTopDown.l2MissMatch.head
```

Finally, this commit also adds DontCare for this new signal to TestTop.scala.