### PR TITLE
Chi coupledl2 retry

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -204,6 +204,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle {
 class PCrdInfo(implicit p: Parameters) extends L2Bundle
     with HasCHIMsgParameters
 {
+  val valid = Bool()
   val srcID = chiOpt.map(_ => UInt(SRCID_WIDTH.W))
   val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
 }

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -142,7 +142,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module {
     pCam(enqIdx).pCrdType.get := io.resps.rxrsp.respInfo.pCrdType.get
   }
 
-  pCamPri := 0.U 
+  pCamPri := 16.U  //out of range of mshrAll 
 
   //each entry zip pCam
   for (i <- 0 until mshrsAll) { //entry

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -42,7 +42,7 @@ class TestTop_CHIL2()(implicit p: Parameters) extends LazyModule {
     masterNode
   }
 
-  val l1d_nodes = (0 until 1) map( i => createClientNode(s"l1d$i", 32))
+  val l1d_nodes = (0 until 1) map( i => createClientNode(s"l1d$i", 128))
   val master_nodes = l1d_nodes
 
   val l2 = LazyModule(new TL2CHICoupledL2())


### PR DESCRIPTION
1. RetryAck -> PCrdGrant  in order, then  use PCrdGrant to match all entrys that needed by judging PCrdInfo {valid, srcID, PCrdType}  (use priority  mux when multi-hit)
2. PCrdGrant -> RetryAck out of order, then use a CAM to record all PCrGrant that is not waited by any MSHRs. When RetryAck come, this MSHR's PCrdInfo will automatically compare with CAM to get the p-credit. (with priority mux when mulit-hit)