### PR TITLE
MSHR, MainPipe: return data when non-fwd RetToSrc snoops hit BRANCH

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -92,10 +92,6 @@ class RXSNP(
   assert(stallCnt <= STALL_CNT_MAX, "stallCnt full! maybe there is a deadlock! addr => 0x%x req_opcode => %d txn_id => %d", io.rxsnp.bits.addr, io.rxsnp.bits.opcode, io.rxsnp.bits.txnID);
 
   assert(!(stall && io.rxsnp.fire))
-  // dontTouch(addrConflictMask)
-  // dontTouch(addrConflict)
-  // dontTouch(replaceConflictMask)
-  // dontTouch(replaceConflict)
 
   def fromSnpToTaskBundle(snp: CHISNP): TaskBundle = {
     val task = WireInit(0.U.asTypeOf(new TaskBundle))

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -172,6 +172,13 @@ object CHIOpcode {
       opcode === SnpCleanShared
     }
 
+    def isSnpToBNonFwd(opcode: UInt): Bool = {
+      widthCheck(opcode)
+      opcode === SnpClean ||
+      opcode === SnpNotSharedDirty ||
+      opcode === SnpShared
+    }
+
     def isSnpToBFwd(opcode: UInt): Bool = {
       widthCheck(opcode)
       opcode === SnpCleanFwd ||


### PR DESCRIPTION
According to CHI specification, for non-forwarding snoops, except SnpMakeInvalid, if the RetToSrc value is 1, a copy of the cache line must be returned if the cache line is Shared Clean and the snoopee retains a copy of the cache line.