### PR TITLE
RXSNP: consider Snp nests a WriteBackFull on an invalid block

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -187,6 +187,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle {
   val blockRefill = Bool()
 
   val metaTag = UInt(tagBits.W)
+  val metaState = UInt(stateBits.W)
   val dirHit = Bool()
 
   // to drop duplicate prefetch reqs

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -946,6 +946,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module {
   io.msInfo.bits.blockRefill := releaseNotSent || RegNext(releaseNotSent,false.B) || RegNext(RegNext(releaseNotSent,false.B),false.B)
   io.msInfo.bits.dirHit := dirResult.hit
   io.msInfo.bits.metaTag := dirResult.tag
+  io.msInfo.bits.metaState := meta.state
   io.msInfo.bits.willFree := will_free
   io.msInfo.bits.isAcqOrPrefetch := req_acquire || req_prefetch
   io.msInfo.bits.isPrefetch := req_prefetch

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -23,6 +23,7 @@ import utility._
 import org.chipsalliance.cde.config.Parameters
 import scala.collection.View.Fill
 import coupledL2.{TaskBundle, MSHRInfo, MetaEntry, MergeTaskBundle}
+import coupledL2.MetaData._
 
 class RXSNP(
   lCreditNum: Int = 4 // the number of L-Credits that a receiver can provide
@@ -69,7 +70,7 @@ class RXSNP(
   )).asUInt
   val replaceBlockSnp = replaceBlockSnpMask.orR
   val replaceNestSnpMask = VecInit(io.msInfo.map(s =>
-      s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit &&
+      s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit && s.bits.metaState =/= INVALID &&
       s.bits.w_replResp && s.bits.w_rprobeacklast && !s.bits.w_releaseack
     )).asUInt
   val replaceDataMask = VecInit(io.msInfo.map(_.bits.replaceData)).asUInt


### PR DESCRIPTION
When two snoops are going to probe the same cache line that L2 already sent WriteBackFull but haven't received CompDBIDResp yet, the former snoop will invalidate the block, therefore the latter snoop must not return SnpRespData, cause there is no valid data any more.