### PR TITLE
configs: use single hartid

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -90,7 +90,7 @@ case class L2Param
     e = BufferParams.default
   ),
 
-  hartIds: Seq[Int] = Seq[Int](),
+  hartId: Int = 0,
   // Prefetch
   prefetch: Option[PrefetchParameters] = None,
   // Performance analysis

--- a/src/main/scala/coupledL2/TopDownMonitor.scala
+++ b/src/main/scala/coupledL2/TopDownMonitor.scala
@@ -31,31 +31,29 @@ class TopDownMonitor()(implicit p: Parameters) extends L2Module {
     val latePF    = Vec(banks, Input(Bool()))
     val debugTopDown = new Bundle {
       val robTrueCommit = Input(UInt(64.W))
-      val robHeadPaddr = Vec(cacheParams.hartIds.length, Flipped(Valid(UInt(36.W))))
-      val l2MissMatch = Vec(cacheParams.hartIds.length, Output(Bool()))
+      val robHeadPaddr = Flipped(Valid(UInt(36.W)))
+      val l2MissMatch = Output(Bool())
     }
   })
 
   /* ====== PART ONE ======
    * Check whether the Addr given by core is a Miss in Cache
    */
-  for (((hartId, pAddr), addrMatch) <- cacheParams.hartIds zip io.debugTopDown.robHeadPaddr zip io.debugTopDown.l2MissMatch) {
-    val addrMatchVec = io.msStatus.zipWithIndex.map {
-      case(slice, i) =>
-        slice.map {
-          ms =>
-            val msBlockAddr = if(bankBits == 0) Cat(ms.bits.reqTag, ms.bits.set)
-              else Cat(ms.bits.reqTag, ms.bits.set, i.U(bankBits-1, 0))
-            val pBlockAddr  = (pAddr.bits >> 6.U).asUInt
-            val isMiss = ms.valid && ms.bits.is_miss
+  val addrMatchVec = io.msStatus.zipWithIndex.map {
+    case(slice, i) =>
+      slice.map {
+        ms =>
+          val msBlockAddr = if(bankBits == 0) Cat(ms.bits.reqTag, ms.bits.set)
+            else Cat(ms.bits.reqTag, ms.bits.set, i.U(bankBits-1, 0))
+          val pBlockAddr  = (io.debugTopDown.robHeadPaddr.bits >> 6.U).asUInt
+          val isMiss = ms.valid && ms.bits.is_miss
 
-            pAddr.valid && (msBlockAddr === pBlockAddr) && isMiss
-        }
-    }
-
-    addrMatch := Cat(addrMatchVec.flatten).orR
-    XSPerfAccumulate(cacheParams, s"${cacheParams.name}MissMatch_${hartId}", addrMatch)
+          io.debugTopDown.robHeadPaddr.valid && (msBlockAddr === pBlockAddr) && isMiss
+      }
   }
+
+  io.debugTopDown.l2MissMatch := Cat(addrMatchVec.flatten).orR
+  XSPerfAccumulate(cacheParams, s"${cacheParams.name}MissMatch_${cacheParams.hartId}", io.debugTopDown.l2MissMatch)
 
   /* ====== PART TWO ======
    * Count the parallel misses, and divide them into CPU/Prefetch

--- a/src/main/scala/coupledL2/debug/Monitor.scala
+++ b/src/main/scala/coupledL2/debug/Monitor.scala
@@ -85,9 +85,8 @@ class Monitor(implicit p: Parameters) extends L2Module {
 
 
   /* ======== ChiselDB ======== */
-//  assert(cacheParams.hartIds.length == 1, "private L2 should have one and only one hardId")
   if (cacheParams.enableMonitor && !cacheParams.FPGAPlatform) {
-    val hartId = if (cacheParams.hartIds.length == 1) cacheParams.hartIds.head else 0
+    val hartId = cacheParams.hartId
     val table = ChiselDB.createTable(s"L2MP", new CPL2S3Info, basicDB = true)
     val s3Info = Wire(new CPL2S3Info)
     s3Info.mshrTask := req_s3.mshrTask

--- a/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
+++ b/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
@@ -137,8 +137,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
 
   /* Constantin Parameters */
 
-  require(cacheParams.hartIds.size == 1)
-  val hartid = cacheParams.hartIds.head
+  val hartid = cacheParams.hartId
   // 0 / 1: whether to enable temporal prefetcher
   private val enableTP = Constantin.createRecord("enableTP"+hartid.toString, initValue = 1)
   // 0 ~ N: throttle cycles for each prefetch request


### PR DESCRIPTION
Before this commit, we use HartIds: Seq[Int] in L2Param. However, it will only contain one element since the code is copied from L3, and L2 is now private to a core, which confuses some developers and causes a bug [1]. To prevent it from happening again, we should use a single HartId here and refactor many of its consumers to use a single HartId.

[1] https://github.com/OpenXiangShan/XiangShan/pull/2966#issuecomment-2105632630