### PR TITLE
MMIOBridge: fix bug in DataID and CCID for DAT channels

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -215,8 +215,8 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   txdat.bits.tgtID := srcID
   txdat.bits.txnID := dbID
   txdat.bits.opcode := DATOpcodes.NonCopyBackWrData
-  txdat.bits.ccID := 0.U
-  txdat.bits.dataID := 0.U
+  txdat.bits.ccID := Cat(req.address(log2Ceil(beatBytes)), 0.U(1.W))
+  txdat.bits.dataID := Cat(req.address(log2Ceil(beatBytes)), 0.U(1.W))
   txdat.bits.be := ParallelLookUp(
     reqWordIdx,
     List.tabulate(words)(i => i.U -> (ZeroExt(req.mask, BE_WIDTH) << (i * wordBytes)))


### PR DESCRIPTION
A transaction size of up to 16-byte is always contained in a single packet. The DataID field value must be set to Addr[5:4] because the DataID field represents Addr[5:4] of the lowest addressed byte within the packet.