### PR TITLE
TestTop: fixed parameter passing of CHI test top

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -106,7 +106,7 @@ case class L2Param(
   FPGAPlatform: Boolean = false,
 
   // Network layer SAM
-  sam: Seq[(AddressSet, Int)] = Seq(AddressSet.everything -> 33)
+  sam: Seq[(AddressSet, Int)] = Seq(AddressSet.everything -> 0)
 ) {
   def toCacheParams: CacheParameters = CacheParameters(
     name = name,


### PR DESCRIPTION
* Fixed non-consistent parameter passing of CHI test top
* Changed default TgtId of L2 from 33 to 0 for NoC implementation compatibility (For general cases, the TgtId of HN or NoC components should be specified through the TestTop parameters rather than adopting to the default)