### PR TITLE
Directory: fixed X-state leakage from RRIP meta SRAM without reset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *       @Ivyfeather @linjuanZ
-src/main/scala/coupledL2/Directory.scala @cailuoshan
-src/main/scala/coupledL2/utils/ @cailuoshan
+src/main/scala/coupledL2/Directory.scala @cailuoshan @linjuanZ
+src/main/scala/coupledL2/utils/ @cailuoshan @linjuanZ
 src/main/scala/coupledL2/prefetch/ @Maxpicca-Li
 src/main/scala/coupledL2/prefetch/ @wakafa1
 src/test/scala/ @Kumonda221-CrO3

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -282,14 +282,14 @@ class Directory(implicit p: Parameters) extends L2Module {
   val rrip_hit_s3 = Mux(refillReqValid_s3, false.B, hit_s3)
   // origin-bit marks whether the data_block is reused
   val origin_bit_opt = if(random_repl) None else
-    Some(Module(new SRAMTemplate(Bool(), sets, ways, singlePort = true)))
+    Some(Module(new SRAMTemplate(Bool(), sets, ways, singlePort = true, shouldReset = true)))
   val origin_bits_r = origin_bit_opt.get.io.r(io.read.fire, io.read.bits.set).resp.data
   val origin_bits_hold = Wire(Vec(ways, Bool()))
   origin_bits_hold := HoldUnless(origin_bits_r, RegNext(io.read.fire, false.B))
   origin_bit_opt.get.io.w(
-      replacerWen,
-      rrip_hit_s3,
-      req_s3.set,
+      !resetFinish || replacerWen,
+      Mux(resetFinish, rrip_hit_s3, false.B),
+      Mux(resetFinish, req_s3.set, resetIdx),
       UIntToOH(touch_way_s3)
   )
 


### PR DESCRIPTION
* To fix the X-state leakage for accurate quad-state simulation
* The original code **SHOULD WORK** without reset in ASIC-only senario
* The original code **SHOULD WORK** without reset in non-quad-state, typically dual-state simulation platform (e.g. verilator)
* The original code **SHOULD WORK** without reset in quad-state simulation platform if SRAMTemplate able to emit randomized data in non-reset state (**not cutting off all X, Z states** in simulation procedure and considering **only the implementation of SRAMTemplate**)
* **The necessity of the reset procedure** of RRIP meta SRAM needed to be disscussed
* **The necessity of the utilization of SRAM** for single-bit RRIP meta 'origin_bit_opt' and other narrow-bit meta fields needed to be discussed