### PR TITLE
SinkC: fix the incorrect invalidation of beatValids

### DIFF
--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -184,7 +184,7 @@ class SinkC(implicit p: Parameters) extends L2Module {
 
   io.bufResp.data := RegNext(RegEnable(dataBuf(io.task.bits.bufIdx), io.task.fire))
   when(RegNext(io.task.fire)) {
-    beatValids(io.task.bits.bufIdx).foreach(_ := false.B)
+    beatValids(RegNext(io.task.bits.bufIdx)).foreach(_ := false.B)
   }
 
   // Performance counters


### PR DESCRIPTION
The beatValids in SinkC is incorrectly invalid, which will cause dataBuf occasionally to be full and cannot accept following Release