### PR TITLE
MSHR: fix a dual-core bug when two client L2s send AcquireBlock BToT

### DIFF
--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -351,7 +351,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     )
     mp_grant.metaWen := true.B
     mp_grant.tagWen := !dirResult.hit
-    mp_grant.dsWen := (!dirResult.hit || gotDirty) && gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))
+    mp_grant.dsWen := gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)
     mp_grant.replTask := !dirResult.hit // Get and Alias are hit that does not need replacement


### PR DESCRIPTION
This bug will be triggered when the the following events occur in sequence:

* Two client L2s send AcquireBlock BToT for the same target block

* One L2 first obtains T permissions, and another L2 is probed

* L3 sends a probe to the L2 that initially obtained T permission due to a client directory conflict. This probe meets the probeAckThrough condition, causing the dirty block to be written to memory

* L3 responds to the Acquire request from the other L2, retrieves the data from memory, and sends it to that L2 cache.

When the above events occur in sequence, since the directory read happens before Acquire request is sent, the L2 whose request is responded later will assume that it has B permission. Consequently, the granted data will not be written into the dataStorage. When the next Probe/Release occurs, if L1 does not return dirty data, the L2 cache will return the stale, incorrect data to L3.

This commit fixes the bug by modifying the `mp_grant.dsWen` signal to ensure that as long as a GrantData response is received, it will be written to the dataStorage.