### PR TITLE
Directory: fix bug for req_type

### DIFF
--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -297,7 +297,7 @@ class Directory(implicit p: Parameters) extends L2Module {
     val req_type = WireInit(0.U(4.W))
     req_type := Cat(origin_bits_hold(way_s3),
                     req_s3.replacerInfo.channel(2),
-                    (req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || req_s3.replacerInfo.refill_prefetch,
+                    (!refillReqValid_s3 && req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || (refillReqValid_s3 && req_s3.replacerInfo.refill_prefetch),
                     req_s3.refill
                     )
     
@@ -316,10 +316,10 @@ class Directory(implicit p: Parameters) extends L2Module {
     // req_type[1]: 0-non-prefetch, 1-prefetch; req_type[0]: 0-not-refill, 1-refill
     val req_type = WireInit(0.U(4.W))
     req_type := Cat(origin_bits_hold(way_s3),
-      req_s3.replacerInfo.channel(2),
-      (req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || req_s3.replacerInfo.refill_prefetch,
-      req_s3.refill
-    )
+                    req_s3.replacerInfo.channel(2),
+                    (!refillReqValid_s3 && req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || (refillReqValid_s3 && req_s3.replacerInfo.refill_prefetch),
+                    req_s3.refill
+                   )
     
     // Set Dueling
     val PSEL = RegInit(512.U(10.W)) //32-monitor sets, 10-bits psel

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -290,18 +290,19 @@ class Directory(implicit p: Parameters) extends L2Module {
       Mux(resetFinish, req_s3.set, resetIdx),
       UIntToOH(way_s3)
   )
+  val rrip_req_type = WireInit(0.U(4.W))
+  // [3]: 0-firstuse, 1-reuse;
+  // [2]: 0-acquire, 1-release;
+  // [1]: 0-non-prefetch, 1-prefetch;
+  // [0]: 0-not-refill, 1-refill
+  rrip_req_type := Cat(origin_bits_hold(way_s3),
+    req_s3.replacerInfo.channel(2),
+    (!refillReqValid_s3 && req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || (refillReqValid_s3 && req_s3.replacerInfo.refill_prefetch),
+    req_s3.refill
+  )
 
   if(cacheParams.replacement == "srrip"){
-    // req_type[3]: 0-firstuse, 1-reuse; req_type[2]: 0-acquire, 1-release;
-    // req_type[1]: 0-non-prefetch, 1-prefetch; req_type[0]: 0-not-refill, 1-refill
-    val req_type = WireInit(0.U(4.W))
-    req_type := Cat(origin_bits_hold(way_s3),
-                    req_s3.replacerInfo.channel(2),
-                    (!refillReqValid_s3 && req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || (refillReqValid_s3 && req_s3.replacerInfo.refill_prefetch),
-                    req_s3.refill
-                    )
-    
-    val next_state_s3 = repl.get_next_state(repl_state_s3, way_s3, hit_s3, inv, req_type)
+    val next_state_s3 = repl.get_next_state(repl_state_s3, way_s3, hit_s3, inv, rrip_req_type)
     val repl_init = Wire(Vec(ways, UInt(2.W)))
     repl_init.foreach(_ := 2.U(2.W))
     replacer_sram_opt.get.io.w(
@@ -312,15 +313,6 @@ class Directory(implicit p: Parameters) extends L2Module {
     )
     
   } else if(cacheParams.replacement == "drrip"){
-    // req_type[3]: 0-firstuse, 1-reuse; req_type[2]: 0-acquire, 1-release;
-    // req_type[1]: 0-non-prefetch, 1-prefetch; req_type[0]: 0-not-refill, 1-refill
-    val req_type = WireInit(0.U(4.W))
-    req_type := Cat(origin_bits_hold(way_s3),
-                    req_s3.replacerInfo.channel(2),
-                    (!refillReqValid_s3 && req_s3.replacerInfo.channel(0) && req_s3.replacerInfo.opcode === Hint) || (req_s3.replacerInfo.channel(2) && metaAll_s3(way_s3).prefetch.getOrElse(false.B)) || (refillReqValid_s3 && req_s3.replacerInfo.refill_prefetch),
-                    req_s3.refill
-                   )
-    
     // Set Dueling
     val PSEL = RegInit(512.U(10.W)) //32-monitor sets, 10-bits psel
     // track monitor sets' hit rate for each policy
@@ -343,7 +335,7 @@ class Directory(implicit p: Parameters) extends L2Module {
                     Mux(match_b, true.B,
                       Mux(PSEL(9)===0.U, false.B, true.B)))    // false.B - srrip, true.B - brrip
 
-    val next_state_s3 = repl.get_next_state(repl_state_s3, way_s3, hit_s3, inv, repl_type, req_type)
+    val next_state_s3 = repl.get_next_state(repl_state_s3, way_s3, hit_s3, inv, repl_type, rrip_req_type)
 
     val repl_init = Wire(Vec(ways, UInt(2.W)))
     repl_init.foreach(_ := 2.U(2.W))

--- a/src/main/scala/coupledL2/utils/Replacer.scala
+++ b/src/main/scala/coupledL2/utils/Replacer.scala
@@ -332,16 +332,19 @@ class StaticRRIP(n_ways: Int) extends ReplacementPolicy {
     val increcement = 3.U(2.W) - State(touch_way)
     // req_type[3]: 0-firstuse, 1-reuse; req_type[2]: 0-acquire, 1-release;
     // req_type[1]: 0-non-prefetch, 1-prefetch; req_type[0]: 0-not-refill, 1-refill
-    // rrpv: non-pref_hit/non-pref_refill(miss)/non-pref_release_reuse = 0; 
-    // pref_hit do nothing; pref_refill = 1; non-pref_release_firstuse/pref_release = 2; 
+    // rrpv: non-pref_hit/non-pref_refill(miss)/non-pref_release_reuse = 0;
+    // pref_hit do nothing; pref_refill = 1; non-pref_release_firstuse/pref_release = 2;
     nextState.zipWithIndex.map { case (e, i) =>
-      e := Mux(i.U === touch_way, 
-              Mux((req_type(2,0) === 0.U && hit) || req_type(2,0) === 1.U || req_type === 12.U, 0.U,
-                  Mux(req_type(2,0) === 3.U, 1.U,
-                      Mux(req_type === 4.U || req_type(2,0) === 6.U, 2.U, State(i)))),
-              //Mux(hit, 0.U(2.W), 2.U(2.W)),
-              Mux(hit || invalid, State(i), State(i)+increcement) 
-            )
+      e := Mux(i.U === touch_way,
+        // for touch_way
+        MuxCase(State(i), Seq(
+          ((req_type(2,0) === 0.U && hit) || req_type(2,0) === 1.U || req_type === 12.U) -> 0.U,
+          (req_type(2,0) === 3.U) -> 1.U,
+          (req_type === 4.U || req_type(2,0) === 6.U) -> 2.U
+        )),
+        // for other ways
+        Mux(hit || invalid, State(i), State(i)+increcement)
+      )
     }
     Cat(nextState.map(x=>x).reverse)
   }
@@ -392,16 +395,19 @@ class BRRIP(n_ways: Int) extends ReplacementPolicy {
     val increcement = 3.U(2.W) - State(touch_way)
     // req_type[3]: 0-firstuse, 1-reuse; req_type[2]: 0-acquire, 1-release;
     // req_type[1]: 0-non-prefetch, 1-prefetch; req_type[0]: 0-not-refill, 1-refill
-    // rrpv: non-pref_hit/non-pref_refill(miss)/non-pref_release_reuse = 0; 
-    // pref_hit do nothing; pref_refill = 1; non-pref_release_firstuse/pref_release = 3; 
+    // rrpv: non-pref_hit/non-pref_refill(miss)/non-pref_release_reuse = 0;
+    // pref_hit do nothing; pref_refill = 1; non-pref_release_firstuse/pref_release = 3;
     nextState.zipWithIndex.map { case (e, i) =>
       e := Mux(i.U === touch_way,
-              Mux((req_type(2,0) === 0.U && hit) || req_type(2,0) === 1.U || req_type === 12.U, 0.U,
-                  Mux(req_type(2,0) === 3.U, 1.U,
-                      Mux(req_type === 4.U || req_type(2,0) === 6.U, 3.U, State(i)))),
-              //Mux(hit, 0.U(2.W), 3.U(2.W)), 
-              Mux(hit || invalid, State(i), State(i)+increcement) 
-            )
+        // for touch_way
+        MuxCase(State(i), Seq(
+          ((req_type(2,0) === 0.U && hit) || req_type(2,0) === 1.U || req_type === 12.U) -> 0.U,
+          (req_type(2,0) === 3.U) -> 1.U,
+          (req_type === 4.U || req_type(2,0) === 6.U) -> 3.U
+        )),
+        // for other ways
+        Mux(hit || invalid, State(i), State(i)+increcement)
+      )
     }
     /* val random = (rand.nextInt(32)).U 
     nextState.zipWithIndex.map { case (e, i) =>


### PR DESCRIPTION
When Refill, replacerInfo.channel=1, opcode=5 is not Hint, but Grant.
req_type will be used to update RRIP repl_state.