### PR TITLE
MMIOBridge: fix bug in CCID assignment

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -205,7 +205,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   txdat.bits.tgtID := srcID
   txdat.bits.txnID := dbID
   txdat.bits.opcode := DATOpcodes.NonCopyBackWrData
-  txdat.bits.ccID := Cat(req.address(log2Ceil(beatBytes)), 0.U(1.W))
+  txdat.bits.ccID := req.address(log2Ceil(beatBytes), log2Ceil(beatBytes) - CCID_WIDTH + 1)
   txdat.bits.dataID := Cat(req.address(log2Ceil(beatBytes)), 0.U(1.W))
   txdat.bits.be := ParallelLookUp(
     reqWordIdx,


### PR DESCRIPTION
The CCID field must match the value of Addr[5:4] of the original request. For data bus width of 256 bits only the upper order CCID and DataID bits must match.