### PR TITLE
MSHR: fix bug when SnpOnce hits on a TRUNK block

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -491,7 +491,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module {
         * 3. If the snoop is SnpCleanShared
         * Otherwise, the dirty bit should stay the same as before.
         */
-      dirty = !snpToN && !snpToB && req_chiOpcode =/= SnpCleanShared && meta.dirty,
+      dirty = !snpToN && !snpToB && req_chiOpcode =/= SnpCleanShared && meta.dirty ||
+        isSnpOnceX(req_chiOpcode) && probeDirty,
       state = Mux(
         snpToN,
         INVALID,


### PR DESCRIPTION
When a SnpOnce hits on a TRUNK block, CoupledL2 will probe upstream cache to acquire the most up-to-date block. When DCache in XiangShan receives Probe toT on a dirty cache line, DCache will echo ProbeAckData TtoT to L2, and erase the dirty flag. Therefore either DCache reserves the dirty flag or L2 marks the block dirty on ProbeAckData TtoT to make sure the dirty data will not be lost. This commit adopts the latter solution.