### PR TITLE
MSHR: fix bug in `DBID` field of CompData with DCT

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -705,6 +705,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module {
     mp_dct.srcID.get := 0.U
     mp_dct.txnID.get := req.fwdTxnID.get
     mp_dct.homeNID.get := req.srcID.get
+    mp_dct.dbID.get := req.txnID.get
     mp_dct.chiOpcode.get := CompData
     mp_dct.resp.get := setPD(fwdCacheState, fwdPassDirty)
     mp_dct.fwdState.get := 0.U


### PR DESCRIPTION
In a snoop DCT transaction, the RN-F provides the read data in CompData that is sent directly to peer RN-F and the DBID must be set to the same value as the TxnID of the snoop.