### PR TITLE
SRAM: implement real MCP2 logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,44 +5,55 @@ init:
 compile:
 	mill -i CoupledL2.compile
 
+TOP = TestTop
+BUILD_DIR = ./build
+TOP_V = $(BUILD_DIR)/$(TOP).v
+SIM_MEM_ARGS = --infer-rw --repl-seq-mem -c:$(TOP):-o:$(TOP).v.conf
+MEM_GEN = ./scripts/vlsi_mem_gen
+MEM_GEN_SEP = ./scripts/gen_sep_mem.sh
+
+test-top:
+	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS)
+	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
+
 test-top-l2:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_L2 -td build
+	$(MAKE) test-top SYSTEM=L2
 
 test-top-l2standalone:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_L2_Standalone -td build
+	$(MAKE) test-top SYSTEM=L2_Standalone
 
 test-top-l2l3:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_L2L3 -td build
+	$(MAKE) test-top SYSTEM=L2L3
 
 test-top-l2l3l2:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_L2L3L2 -td build
+	$(MAKE) test-top SYSTEM=L2L3L2
 
 test-top-fullsys:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_fullSys -td build
+	$(MAKE) test-top SYSTEM=fullSys
 
 test-top-chi-dualcore-0ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_DualCore_0UL -td build
+	$(MAKE) test-top SYSTEM=CHI_DualCore_0UL
 
 test-top-chi-dualcore-2ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_DualCore_2UL -td build
+	$(MAKE) test-top SYSTEM=CHI_DualCore_2UL
 
 test-top-chi-quadcore-0ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_QuadCore_0UL -td build
+	$(MAKE) test-top SYSTEM=CHI_QuadCore_0UL
 
 test-top-chi-quadcore-2ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_QuadCore_2UL -td build
+	$(MAKE) test-top SYSTEM=CHI_QuadCore_2UL
 
 test-top-chi-octacore-0ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_OctaCore_0UL -td build
+	$(MAKE) test-top SYSTEM=CHI_OctaCore_0UL
 
 test-top-chi-octacore-2ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_OctaCore_2UL -td build
+	$(MAKE) test-top SYSTEM=CHI_OctaCore_2UL
 
 test-top-chi-hexacore-0ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_HexaCore_0UL -td build
+	$(MAKE) test-top SYSTEM=CHI_HexaCore_0UL
 
 test-top-chi-hexacore-2ul:
-	mill -i CoupledL2.test.runMain coupledL2.TestTop_CHI_HexaCore_2UL -td build
+	$(MAKE) test-top SYSTEM=CHI_HexaCore_2UL
 
 clean:
 	rm -rf ./build
@@ -58,3 +69,5 @@ reformat:
 
 checkformat:
 	mill -i __.checkFormat
+
+.PHONY: init bsp checkformat clean compile idea reformat 

--- a/scripts/gen_sep_mem.sh
+++ b/scripts/gen_sep_mem.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mem_script=$1
+conf_file=$2
+output_dir=$3
+
+IFS=$'\n'
+for line in `cat $conf_file`; do
+  file=`echo "$line" | grep -oP '(?<=name )[^ ]*(?= .*)'`
+  echo $line >${conf_file}.tmp
+  ${mem_script} ${conf_file}.tmp -o ${output_dir}/${file}.v
+done
+
+rm ${conf_file}.tmp

--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -1,0 +1,450 @@
+#! /usr/bin/env python3
+
+# See LICENSE.SiFive for license details.
+# See LICENSE.Berkeley for license details.
+
+import sys
+import math
+
+use_latches = 0
+
+class VerilogModuleGenerator(object):
+  def __init__(self, name):
+    self.name = name
+    self.port_spec = []
+    self.decl = []
+    self.combinational = []
+    self.sequential = []
+
+  def __format_width(self, width):
+    return "[{}:0] ".format(width-1) if width > 1 else ""
+
+  def __format_depth(self, depth):
+    return " [{}:0]".format(depth-1) if depth > 1 else ""
+
+  def add_io(self, io_type, width, name):
+    width_str = self.__format_width(width)
+    # print(io_type, width_str, name)
+    self.port_spec.append(f'{io_type} {width_str}{name}')
+
+  def add_input(self, width, name):
+    self.add_io("input", width, name)
+
+  def add_output(self, width, name):
+    self.add_io("output", width, name)
+
+  def add_decl(self, decl_type, width, name, depth=1):
+    width_str = self.__format_width(width)
+    depth_str = self.__format_depth(depth)
+    self.decl.append(f"{decl_type} {width_str}{name}{depth_str};")
+
+  def add_decl_reg(self, width, name, depth=1):
+    self.add_decl("reg", width, name, depth)
+
+  def add_decl_ram(self, width, name, depth=1):
+    width_str = self.__format_width(width)
+    depth_str = " [{}:0]".format(depth-1)
+    self.decl.append(f"reg {width_str}{name}{depth_str};")
+
+  def add_decl_wire(self, width, name, depth=1):
+    self.add_decl("wire", width, name, depth)
+
+  def add_decl_line(self, line):
+    self.decl.append(line)
+
+  def add_sequential(self, line):
+    self.sequential.append(line)
+
+  def add_combinational(self, line):
+    self.combinational.append(line)
+
+  def generate(self, blackbox):
+    body = "\
+  %s\n\
+  %s\n\
+  %s\n" % ('\n  '.join(self.decl), '\n  '.join(self.sequential), '\n  '.join(self.combinational))
+
+    s = "\nmodule %s(\n\
+  %s\n\
+);\n\
+\n\
+%s\
+\n\
+endmodule" % (self.name, ',\n  '.join(self.port_spec), body if not blackbox else blackbox)
+    return s
+
+
+class Reshaper(object):
+  def __init__(self, before, after):
+    # print(before, after)
+    self.conf = before
+    self.new_conf = after
+    assert(self.conf[-1] == ['write', 'read'])
+    assert(self.new_conf[-1] == ['mwrite', 'read'])
+
+  def generate(self, mem):
+    (name, width, depth, mask_gran, mask_seg, _) = self.conf
+    (new_name, new_width, new_depth, new_mask_gran, new_mask_seg, _) = self.new_conf
+    addr_bits = math.log2(depth)
+    ways = new_width // width
+    ways_bits = int(math.log2(ways))
+    mem.add_decl_wire(new_width, "data_read")
+    mem.add_decl_wire(new_width, "data_write")
+    mem.add_combinational(f"assign data_write = ")
+    sels = [f"{f'(write_way_index == {w}) ?' if w != ways-1 else ''} ({{{new_width-width}'h0, W0_data}} << {width*w})" for w in range(ways)]
+    mem.add_combinational(":\n    ".join(sels) + ";")
+    mem.add_decl_wire(ways_bits, "read_way_index")
+    mem.add_combinational(f"assign read_way_index = R0_addr[{ways_bits-1}:0];")
+    mem.add_decl_wire(ways_bits, "write_way_index")
+    mem.add_combinational(f"assign write_way_index = W0_addr[{ways_bits-1}:0];")
+    mem.add_combinational(f"{new_name} array (")
+    mem.add_combinational(f"  .W0_clk(W0_clk),")
+    mem.add_combinational(f"  .W0_addr(W0_addr[{new_width-1}:{ways_bits}]),")
+    mem.add_combinational(f"  .W0_en(W0_en),")
+    mem.add_combinational(f"  .W0_data(data_write),")
+    mem.add_combinational(f"  .W0_mask({ways}'h1 << write_way_index),")
+    mem.add_combinational(f"  .R0_clk(R0_clk),")
+    mem.add_combinational(f"  .R0_addr(R0_addr[{new_width-1}:{ways_bits}]),")
+    mem.add_combinational(f"  .R0_en(R0_en),")
+    mem.add_combinational(f"  .R0_data(data_read)")
+    mem.add_combinational(f");")
+    mem.add_combinational(f"assign R0_data = ")
+    sels = [f"{f'(read_way_index == {w}) ?' if w != ways-1 else ''} data_read[{width*(w+1)-1}:{width*w}]" for w in range(ways)]
+    mem.add_combinational(":\n    ".join(sels) + ";")
+
+
+class Spliter(object):
+  def __init__(self, before, after):
+    # print(before, after)
+    self.conf = before
+    self.new_conf = after
+    assert(self.conf[-1] == ['mrw'])
+    assert(self.new_conf[-1] == ['rw'])
+
+  def generate(self, mem):
+    (name, width, depth, mask_gran, mask_seg, _) = self.conf
+    (new_name, new_width, new_depth, new_mask_gran, new_mask_seg, _) = self.new_conf
+    assert(depth == new_depth)
+    ways = width // new_width
+    for i in range(ways):
+      data_slice = f"[{new_width*(i+1)-1}:{new_width*i}]"
+      mem.add_combinational(f"{new_name} array_{i} (")
+      mem.add_combinational(f"  .RW0_clk(RW0_clk),")
+      mem.add_combinational(f"  .RW0_addr(RW0_addr),")
+      mem.add_combinational(f"  .RW0_en(RW0_en),")
+      mem.add_combinational(f"  .RW0_wmode(RW0_wmode && RW0_wmask[{i}]),")
+      mem.add_combinational(f"  .RW0_wdata(RW0_wdata{data_slice}),")
+      mem.add_combinational(f"  .RW0_rdata(RW0_rdata{data_slice})")
+      mem.add_combinational(f");")
+
+class SRAM(object):
+  def __init__(self, line):
+    self.parse_line(line)
+    self.prepare_module()
+
+  def parse_line(self, line):
+    name = ''
+    width = 0
+    depth = 0
+    ports = ''
+    mask_gran = 0
+    read_mcp2 = 0  # or generalize as read-latency
+    tokens = line.split()
+    i = 0
+    for i in range(0, len(tokens), 2):
+      s = tokens[i]
+      if s == 'name':
+        name = tokens[i+1]
+        if 'mcp2' in name:
+          read_mcp2 = 1
+      elif s == 'width':
+        width = int(tokens[i+1])
+        mask_gran = width # default setting
+      elif s == 'depth':
+        depth = int(tokens[i+1])
+      elif s == 'ports':
+        ports = tokens[i+1].split(',')
+      elif s == 'mask_gran':
+        mask_gran = int(tokens[i+1])
+      else:
+        sys.exit('%s: unknown argument %s' % (sys.argv[0], i))
+    self.conf = (name, width, depth, mask_gran, width//mask_gran, ports, read_mcp2)
+  # return (name, width, depth, mask_gran, width//mask_gran, ports)
+
+  def prepare_module(self):
+    (name, width, depth, mask_gran, mask_seg, ports, _) = self.conf
+    addr_width = max(math.ceil(math.log(depth)/math.log(2)),1)
+
+    mem = VerilogModuleGenerator(name)
+    readports = []
+    writeports = []
+    latchports = []
+    rwports = []
+    maskedports = {}
+
+    for pid, ptype in enumerate(ports):
+      if ptype[0:1] == 'm':
+        ptype = ptype[1:]
+        maskedports[pid] = pid
+
+      if ptype == 'read':
+        prefix = 'R%d_' % len(readports)
+        mem.add_input(1, prefix + "clk")
+        mem.add_input(addr_width, prefix + "addr")
+        mem.add_input(1, prefix + "en")
+        mem.add_output(width, prefix + "data")
+        readports.append(pid)
+      elif ptype == 'write':
+        prefix = 'W%d_' % len(writeports)
+        mem.add_input(1, prefix + "clk")
+        mem.add_input(addr_width, prefix + "addr")
+        mem.add_input(1, prefix + "en")
+        mem.add_input(width, prefix + "data")
+        if pid in maskedports:
+          mem.add_input(mask_seg, prefix + "mask")
+        if not use_latches or pid in maskedports:
+          writeports.append(pid)
+        else:
+          latchports.append(pid)
+      elif ptype == 'rw':
+        prefix = 'RW%d_' % len(rwports)
+        mem.add_input(1, prefix + "clk")
+        mem.add_input(addr_width, prefix + "addr")
+        mem.add_input(1, prefix + "en")
+        mem.add_input(1, prefix + "wmode")
+        if pid in maskedports:
+          mem.add_input(mask_seg, prefix + "wmask")
+        mem.add_input(width, prefix + "wdata")
+        mem.add_output(width, prefix + "rdata")
+        rwports.append(pid)
+      else:
+        sys.exit('%s: unknown port type %s' % (sys.argv[0], ptype))
+    self.mem = mem
+    self.ports_conf = (readports, writeports, latchports, rwports, maskedports)
+
+  def generate(self, blackbox):
+    (name, width, depth, mask_gran, mask_seg, ports, read_mcp2) = self.conf
+    addr_width = max(math.ceil(math.log(depth)/math.log(2)),1)
+    mem, (readports, writeports, latchports, rwports, maskedports) = self.mem, self.ports_conf
+
+    nr = len(readports)
+    nw = len(writeports)
+    nrw = len(rwports)
+
+    def emit_read(idx, rw):
+      prefix = ('RW%d_' if rw else 'R%d_') % idx
+      data = ('%srdata' if rw else '%sdata') % prefix
+      en = ('%sen && !%swmode' % (prefix, prefix)) if rw else ('%sen' % prefix)
+      mem.add_decl_reg(1, f"reg_{prefix}ren")
+      mem.add_decl_reg(addr_width, f"reg_{prefix}addr")
+      if read_mcp2:
+        mem.add_decl_reg(1, f"reg_{prefix}ren_2")
+        mem.add_decl_reg(addr_width, f"reg_{prefix}addr_2")  
+      mem.add_sequential(f"always @(posedge {prefix}clk)")
+      mem.add_sequential(f"  reg_{prefix}ren <= {en};")
+      mem.add_sequential(f"always @(posedge {prefix}clk)")
+      mem.add_sequential(f"  if ({en}) reg_{prefix}addr <= {prefix}addr;")
+      if read_mcp2:
+        mem.add_sequential(f"always @(posedge {prefix}clk)")
+        mem.add_sequential(f"  reg_{prefix}ren_2 <= reg_{prefix}ren;")
+        mem.add_sequential(f"always @(posedge {prefix}clk)")
+        mem.add_sequential(f"  if (reg_{prefix}ren) reg_{prefix}addr_2 <= reg_{prefix}addr;")
+      mem.add_combinational("`ifdef RANDOMIZE_GARBAGE_ASSIGN")
+      mem.add_combinational(f"reg [{((width-1)//32+1)*32-1}:0] {prefix}random;")
+      mem.add_combinational(f"`ifdef RANDOMIZE_MEM_INIT")
+      mem.add_combinational(f"  initial begin")
+      mem.add_combinational(f"    #`RANDOMIZE_DELAY begin end")
+      mem.add_combinational('    %srandom = {%s};' % (prefix, ', '.join(['$random'] * ((width-1)//32+1))))
+      mem.add_combinational('    reg_%sren = %srandom[0];' % (prefix, prefix))
+      if read_mcp2:
+         mem.add_combinational('    reg_%sren_2 = %srandom[0];' % (prefix, prefix))
+      mem.add_combinational('  end')
+      mem.add_combinational('`endif')
+      mem.add_combinational('always @(posedge %sclk) %srandom <= {%s};' % (prefix, prefix, ', '.join(['$random'] * ((width-1)//32+1))))
+      if not read_mcp2:
+        mem.add_combinational('assign %s = reg_%sren ? ram[reg_%saddr] : %srandom[%d:0];' % (data, prefix, prefix, prefix, width-1))
+      else:
+        mem.add_combinational('assign %s = reg_%sren_2 ? ram[reg_%saddr_2] : %srandom[%d:0];' % (data, prefix, prefix, prefix, width-1))
+      mem.add_combinational('`else')
+      if not read_mcp2:
+        mem.add_combinational('assign %s = ram[reg_%saddr];' % (data, prefix))
+      else:
+        mem.add_combinational('assign %s = ram[reg_%saddr_2];' % (data, prefix))
+
+      mem.add_combinational('`endif')
+
+    for idx in range(nr):
+      emit_read(idx, False)
+
+    for idx in range(nrw):
+      emit_read(idx, True)
+
+    for idx in range(len(latchports)):
+      prefix = 'W%d_' % idx
+      mem.add_decl_reg(addr_width, f"latch_{prefix}addr")
+      mem.add_decl_reg(width, f"latch_{prefix}data")
+      mem.add_decl_reg(1, f"latch_{prefix}en")
+      mem.add_combinational('always @(*) begin')
+      mem.add_combinational('  if (!%sclk && %sen) latch_%saddr <= %saddr;' % (prefix, prefix, prefix, prefix))
+      mem.add_combinational('  if (!%sclk && %sen) latch_%sdata <= %sdata;' % (prefix, prefix, prefix, prefix))
+      mem.add_combinational('  if (!%sclk) latch_%sen <= %sen;' % (prefix, prefix, prefix))
+      mem.add_combinational('end')
+      mem.add_combinational('always @(*)')
+      mem.add_combinational('  if (%sclk && latch_%sen)' % (prefix, prefix))
+      mem.add_combinational('    ram[latch_%saddr] <= latch_%sdata;' % (prefix, prefix))
+
+    mem.add_decl_ram(width, "ram", depth)
+    mem.add_decl_line('`ifdef RANDOMIZE_MEM_INIT')
+    mem.add_decl_line('  integer initvar;')
+    mem.add_decl_line('  initial begin')
+    mem.add_decl_line('    #`RANDOMIZE_DELAY begin end')
+    mem.add_decl_line('    for (initvar = 0; initvar < %d; initvar = initvar+1)' % depth)
+    mem.add_decl_line('      ram[initvar] = {%d {$random}};' % ((width-1)//32+1))
+    prefixes = ['R%d_' % idx for idx in range(nr)] + ['RW%d_' % idx for idx in range(nrw)]
+    for prefix in prefixes:
+      mem.add_decl_line('    reg_%saddr = {%d {$random}};' % (prefix, ((addr_width-1)//32+1)))
+      if read_mcp2:
+        mem.add_decl_line('    reg_%saddr_2 = {%d {$random}};' % (prefix, ((addr_width-1)//32+1)))
+    mem.add_decl_line('  end')
+    mem.add_decl_line('`endif')
+
+    mem.add_decl_line("integer i;")
+    for idx in range(nw):
+      prefix = 'W%d_' % idx
+      pid = writeports[idx]
+      mem.add_sequential('always @(posedge %sclk)' % prefix)
+      mem.add_sequential("  if (%sen) begin" % prefix)
+      for i in range(mask_seg):
+        mask = ('if (%smask[%d]) ' % (prefix, i)) if pid in maskedports else ''
+        ram_range = '%d:%d' % ((i+1)*mask_gran-1, i*mask_gran)
+        mem.add_sequential("    %sram[%saddr][%s] <= %sdata[%s];" % (mask, prefix, ram_range, prefix, ram_range))
+      mem.add_sequential("  end")
+    for idx in range(nrw):
+      pid = rwports[idx]
+      prefix = 'RW%d_' % idx
+      mem.add_sequential('always @(posedge %sclk)' % prefix)
+      mem.add_sequential("  if (%sen && %swmode) begin" % (prefix, prefix))
+      if mask_seg > 0:
+        if mask_gran == 1: # If 1 bit mask, use & instead
+          if pid in maskedports:
+            mem.add_sequential("      ram[%saddr] <= (%swmask & %swdata) | (~%swmask & ram[%saddr]);" %(prefix, prefix, prefix, prefix, prefix))
+          else:
+            mem.add_sequential("      ram[%saddr] <= %swdata;" %(prefix, prefix))
+        else:
+          mem.add_sequential("    for (i=0;i<%d;i=i+1) begin" % mask_seg)
+          if pid in maskedports:
+            mem.add_sequential("      if (%swmask[i]) begin" % prefix)
+            mem.add_sequential("        ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
+            mem.add_sequential("      end")
+          else:
+            mem.add_sequential("      ram[%saddr][i*%d +: %d] <= %swdata[i*%d +: %d];" %(prefix, mask_gran, mask_gran, prefix, mask_gran, mask_gran))
+          mem.add_sequential("    end")
+      mem.add_sequential("  end")
+    return mem.generate(blackbox)
+
+
+class SRAM_TSMC28(SRAM):
+  def __init__(self, line):
+    super().__init__(line)
+    self.sub_srams = []
+    if self.__check_subsrams():
+      print(line.strip())
+
+  def __check_subsrams(self):
+    need_split = self.__split()
+    need_reshape  = self.__reshape()
+    assert(not (need_split and need_reshape))
+    return not need_split and not need_reshape
+
+  def __split(self):
+    (name, width, depth, mask_gran, mask_seg, ports) = self.conf
+    '''if ports == ["mrw"] and mask_gran >= 32:
+      new_conf = (name + "_sub", str(depth), str(mask_gran), "rw")
+      line_field = ("name", "depth", "width", "ports")
+      new_line = " ".join(map(lambda x: " ".join(x), zip(line_field, new_conf)))
+      new_sram = SRAM_TSMC28(new_line)
+      self.sub_srams.append(new_sram)
+      reshaper = Spliter(self.conf, new_sram.conf)
+      reshaper.generate(self.mem)
+      return True'''
+    return False
+
+  def __reshape(self):
+    (name, width, depth, mask_gran, mask_seg, ports) = self.conf
+    if width == 2 and depth == 256:
+      new_conf = (name + "_sub", "64", "8", "mwrite,read", "2")
+      line_field = ("name", "depth", "width", "ports", "mask_gran")
+      new_line = " ".join(map(lambda x: " ".join(x), zip(line_field, new_conf)))
+      new_sram = SRAM_TSMC28(new_line)
+      self.sub_srams.append(new_sram)
+      reshaper = Reshaper(self.conf, new_sram.conf)
+      reshaper.generate(self.mem)
+      return True
+    return False
+
+  def __get_tsmc_lib(self):
+    mem, (readports, writeports, latchports, rwports, maskedports) = self.mem, self.ports_conf
+    blackbox = "// tsmc lib here\n"
+    (name, width, depth, mask_gran, mask_seg, _) = self.conf
+    nports = (len(readports), len(writeports), len(rwports))
+    addr_width = max(math.ceil(math.log(depth)/math.log(2)),1)
+    masked = len(maskedports) > 0
+    # from tsmc28_sram import gen_tsmc_ram_1pw, gen_tsmc_ram_1pnw, gen_tsmc_ram_2pw, gen_tsmc_ram_2pnw
+    # if nports == (1, 1, 0):
+    #   if masked:
+    #     blackbox = gen_tsmc_ram_2pw("TS6N28HPCPLVTA64X8M2F", width, mask_gran)
+    #   else:
+    #     blackbox = gen_tsmc_ram_2pnw("TS6N28HPCPLVTA64X14M2F")
+    # elif nports == (0, 0, 1):
+    #   if masked:
+    #     blackbox = gen_tsmc_ram_1pw('TS1N28HPCPLVTB8192X64M8SW', width, mask_gran, addr_width)
+    #   else:
+    #     blackbox = gen_tsmc_ram_1pnw('TS5N28HPCPLVTA64X144M2F', width, addr_width)
+    # else:
+    #   blackbox = "// unknown tsmc lib type\n"
+    return mem.generate(blackbox)
+
+  def generate(self, blackbox, itself_only=False):
+    if itself_only:
+      # generate splits or reshapes
+      if self.sub_srams:
+        return self.mem.generate("")
+      # use empty blackbox
+      elif blackbox:
+        return super().generate(" ")
+      # insert tsmc libs
+      else:
+        return self.__get_tsmc_lib()
+    else:
+      s = self.generate(blackbox, True)
+      for sram in self.sub_srams:
+        s += sram.generate(blackbox)
+      return s
+
+
+def main(args):
+  f = open(args.output_file, "w") if (args.output_file) else None
+  conf_file = args.conf
+  for line in open(conf_file):
+    sram = SRAM(line)
+    if args.tsmc28:
+      sram = SRAM_TSMC28(line)
+    else:
+      sram = SRAM(line)
+    if f is not None:
+        f.write(sram.generate(args.blackbox))
+    else:
+        print(sram.generate(args.blackbox))
+
+
+if __name__ == '__main__':
+  import argparse
+  parser = argparse.ArgumentParser(description='Memory generator for Rocket Chip')
+  parser.add_argument('conf', metavar='.conf file')
+  parser.add_argument('--tsmc28', action='store_true', help='use tsmc28 sram to generate module body')
+  parser.add_argument('--blackbox', '-b', action='store_true', help='set to disable output of module body')
+  #parser.add_argument('--use_latches', '-l', action='store_true', help='set to enable use of latches')
+  parser.add_argument('--output_file', '-o', help='name of output file, default is stdout')
+  args = parser.parse_args()
+  #use_latches = args.use_latches
+  main(args)

--- a/scripts/vlsi_mem_gen
+++ b/scripts/vlsi_mem_gen
@@ -238,17 +238,18 @@ class SRAM(object):
       mem.add_decl_reg(1, f"reg_{prefix}ren")
       mem.add_decl_reg(addr_width, f"reg_{prefix}addr")
       if read_mcp2:
-        mem.add_decl_reg(1, f"reg_{prefix}ren_2")
-        mem.add_decl_reg(addr_width, f"reg_{prefix}addr_2")  
+        mem.add_decl_wire(1, f"{prefix}addr_diff")
+        mem.add_decl_wire(1, f"{prefix}rdata_valid")
+        mem.add_decl_reg(addr_width, f"reg_{prefix}addr_2")
+        mem.add_combinational(f"assign {prefix}addr_diff = ({prefix}addr != reg_{prefix}addr);")
+        mem.add_combinational(f"assign {prefix}rdata_valid = reg_{prefix}ren && ({prefix}addr_diff || !({en}));")
       mem.add_sequential(f"always @(posedge {prefix}clk)")
       mem.add_sequential(f"  reg_{prefix}ren <= {en};")
       mem.add_sequential(f"always @(posedge {prefix}clk)")
       mem.add_sequential(f"  if ({en}) reg_{prefix}addr <= {prefix}addr;")
       if read_mcp2:
-        mem.add_sequential(f"always @(posedge {prefix}clk)")
-        mem.add_sequential(f"  reg_{prefix}ren_2 <= reg_{prefix}ren;")
-        mem.add_sequential(f"always @(posedge {prefix}clk)")
-        mem.add_sequential(f"  if (reg_{prefix}ren) reg_{prefix}addr_2 <= reg_{prefix}addr;")
+        mem.add_sequential(f"always @(posedge {prefix}rdata_valid)")
+        mem.add_sequential(f"  reg_{prefix}addr_2 <= reg_{prefix}addr;")
       mem.add_combinational("`ifdef RANDOMIZE_GARBAGE_ASSIGN")
       mem.add_combinational(f"reg [{((width-1)//32+1)*32-1}:0] {prefix}random;")
       mem.add_combinational(f"`ifdef RANDOMIZE_MEM_INIT")
@@ -256,15 +257,13 @@ class SRAM(object):
       mem.add_combinational(f"    #`RANDOMIZE_DELAY begin end")
       mem.add_combinational('    %srandom = {%s};' % (prefix, ', '.join(['$random'] * ((width-1)//32+1))))
       mem.add_combinational('    reg_%sren = %srandom[0];' % (prefix, prefix))
-      if read_mcp2:
-         mem.add_combinational('    reg_%sren_2 = %srandom[0];' % (prefix, prefix))
       mem.add_combinational('  end')
       mem.add_combinational('`endif')
       mem.add_combinational('always @(posedge %sclk) %srandom <= {%s};' % (prefix, prefix, ', '.join(['$random'] * ((width-1)//32+1))))
       if not read_mcp2:
         mem.add_combinational('assign %s = reg_%sren ? ram[reg_%saddr] : %srandom[%d:0];' % (data, prefix, prefix, prefix, width-1))
       else:
-        mem.add_combinational('assign %s = reg_%sren_2 ? ram[reg_%saddr_2] : %srandom[%d:0];' % (data, prefix, prefix, prefix, width-1))
+        mem.add_combinational('assign %s = %srdata_valid ? ram[reg_%saddr_2] : %srandom[%d:0];' % (data, prefix, prefix, prefix, width-1))
       mem.add_combinational('`else')
       if not read_mcp2:
         mem.add_combinational('assign %s = ram[reg_%saddr];' % (data, prefix))
@@ -448,3 +447,35 @@ if __name__ == '__main__':
   args = parser.parse_args()
   #use_latches = args.use_latches
   main(args)
+
+# when SRAM rdata path is set multicycle 2, rdata is unstable at the first cycle after read fire,
+# and we should sample rdata at the second cycle after read fire.
+# To simulate this behavior, we modify the SRAM model for MCP2.
+#
+# SRAMs with MCP2 in RTL will use suggestName 'array_mcp2'
+# This script captures 'mcp2' in module name and specialize these SRAMs.
+#
+# SRAMs with MCP2 must also satisfy other requirements:
+# 1. no continuous SRAM reqs (need a gap cycle between two reqs)
+# 2. input signals should hold for at least 2 cycles
+# 3. **use enable to clock gate SRAM**, make sure each req is only sampled once
+# According to these, we implement MCP2 SRAM model as follows
+#
+# === paste the code to WaveDrom Editor to visualize MCP2 behavior ===
+# {signal: [ 
+#   {name:'clk', wave:'p.........'}, 
+#   {name:'clk_mask', wave:'0.plpl.pl.'},
+#   {name:'ren', wave:'01...01.0.'},
+#   {name:'addr', wave:'x3.4.x5.x.'},
+#   {name:'spec_rdata',wave:'x..3x4x.5x'},
+#   {name:''},
+#   {name:'How We Output RDATA two cycles after rfire'},
+#   {name:'ren_reg', wave:'0.1.......'},
+#   {name:'addr_reg', wave:'x.3.4..5..'},
+#   {name:'1.reg_ren && !ren', wave:'0....10.1.'},  // capture negedge of ren
+#   {name:'2.addr_diff', wave:'0x010x10xx'}, // additional when continuous ren
+#   {name:'rdata_valid ='},
+#   {name:'reg_ren && (addr_diff || !ren)', wave:'0..101.01.'},
+#   {name:'rdata',wave:'x..3x4.x5.'},
+# ]
+# }

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -19,8 +19,8 @@ package coupledL2
 
 import chisel3._
 import chisel3.util._
-import coupledL2.utils.SRAMTemplate
-import utility.RegNextN
+import coupledL2.utils.{HoldUnless, SRAMTemplate}
+import utility.ClockGate
 import org.chipsalliance.cde.config.Parameters
 
 class DSRequest(implicit p: Parameters) extends L2Bundle {
@@ -47,19 +47,29 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     val wdata = Input(new DSBlock)
   })
 
+  // read data is set MultiCycle Path 2
   val array = Module(new SRAMTemplate(
     gen = new DSBlock,
     set = blocks,
     way = 1,
-    singlePort = true,
-    holdRead = true
+    singlePort = true
   ))
 
-  val arrayIdx = Cat(io.req.bits.way, io.req.bits.set)
+  val masked_clock = ClockGate(false.B, io.req.valid, clock)
+  array.clock := masked_clock
+
   val wen = io.req.valid && io.req.bits.wen
   val ren = io.req.valid && !io.req.bits.wen
-  array.io.w.apply(wen, io.wdata, arrayIdx, 1.U)
-  array.io.r.apply(ren, arrayIdx)
+
+  // make sure SRAM input signals will not change during the two cycles
+  val holdWen = wen || RegNext(wen)
+  val holdRen = ren || RegNext(ren)
+  val req = HoldUnless(io.req.bits, io.req.valid)
+  val wdata = HoldUnless(io.wdata, io.req.valid)
+  val arrayIdx = Cat(req.way, req.set)
+
+  array.io.w.apply(holdWen, wdata, arrayIdx, 1.U)
+  array.io.r.apply(holdRen, arrayIdx)
 
   // for timing, we set this as multicycle path
   // s3 read, s4 pass and s5 to destination

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -52,7 +52,8 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     gen = new DSBlock,
     set = blocks,
     way = 1,
-    singlePort = true
+    singlePort = true,
+    readMCP2 = true
   ))
 
   val masked_clock = ClockGate(false.B, io.req.valid, clock)

--- a/src/main/scala/coupledL2/utils/BankedSRAM.scala
+++ b/src/main/scala/coupledL2/utils/BankedSRAM.scala
@@ -11,7 +11,7 @@ class BankedSRAM[T <: Data]
   gen: T, sets: Int, ways: Int, n: Int = 1,
   shouldReset: Boolean = false, holdRead: Boolean = false,
   singlePort: Boolean = false, bypassWrite: Boolean = false,
-  clk_div_by_2: Boolean = false
+  clkDivBy2: Boolean = false
 ) extends Module {
   val io = IO(new Bundle() {
     val r = Flipped(new SRAMReadBus(gen, sets, ways))
@@ -33,7 +33,7 @@ class BankedSRAM[T <: Data]
       gen, innerSet, ways,
       shouldReset = shouldReset, holdRead = holdRead,
       singlePort = true, bypassWrite = bypassWrite,
-      clk_div_by_2 = clk_div_by_2
+      clkDivBy2 = clkDivBy2
     ))
     sram.io.r.req.valid := io.r.req.valid && ren
     sram.io.r.req.bits.apply(r_setIdx)
@@ -44,7 +44,7 @@ class BankedSRAM[T <: Data]
 
   val ren_vec_0 = VecInit(banks.map(_.io.r.req.fire))
   val ren_vec_1 = RegNext(ren_vec_0, 0.U.asTypeOf(ren_vec_0))
-  val ren_vec = if(clk_div_by_2){
+  val ren_vec = if(clkDivBy2){
     RegNext(ren_vec_1, 0.U.asTypeOf(ren_vec_0))
   } else ren_vec_1
 

--- a/src/main/scala/coupledL2/utils/SRAMTemplate.scala
+++ b/src/main/scala/coupledL2/utils/SRAMTemplate.scala
@@ -106,7 +106,7 @@ class SRAMWriteBus[T <: Data](private val gen: T, val set: Int, val way: Int = 1
   holdRead: hold read data until next read comes
   singlePort: single port
   bypassWrite: (used for dual port) bypass write data to read data
-  clk_div_by_2: SRAM clock cycle is half of L2 clock cycle
+  clkDivBy2: SRAM clock cycle is half of L2 clock cycle
   readMCP2: SRAM read data is multi-cycle path 2
  */
 class SRAMTemplate[T <: Data]
@@ -114,7 +114,7 @@ class SRAMTemplate[T <: Data]
   gen: T, set: Int, way: Int = 1,
   shouldReset: Boolean = false, holdRead: Boolean = false,
   singlePort: Boolean = false, bypassWrite: Boolean = false,
-  clk_div_by_2: Boolean = false, readMCP2: Boolean = false
+  clkDivBy2: Boolean = false, readMCP2: Boolean = false
 ) extends Module {
   val io = IO(new Bundle {
     val r = Flipped(new SRAMReadBus(gen, set, way))
@@ -165,7 +165,7 @@ class SRAMTemplate[T <: Data]
   }
 
   val rdata = (
-    if(clk_div_by_2) {
+    if(clkDivBy2) {
       DelayTwoCycle(mem_rdata, realRen) // this holdRead as well
     } else if (holdRead) {
       HoldUnless(mem_rdata, RegNext(realRen))
@@ -173,7 +173,7 @@ class SRAMTemplate[T <: Data]
       mem_rdata
     }).map(_.asTypeOf(gen))
 
-  if(clk_div_by_2){
+  if(clkDivBy2){
     CustomAnnotations.annotateClkDivBy2(this)
   }
   if(!isPow2(set)){

--- a/src/main/scala/coupledL2/utils/SRAMTemplate.scala
+++ b/src/main/scala/coupledL2/utils/SRAMTemplate.scala
@@ -97,6 +97,13 @@ class SRAMWriteBus[T <: Data](private val gen: T, val set: Int, val way: Int = 1
   }
 }
 
+/*
+  shouldReset: set all data in SRAM to zero at Reset
+  holdRead: hold read data until next read comes
+  singlePort: single port
+  bypassWrite: (used for dual port) bypass write data to read data
+  clk_div_by_2: SRAM clock cycle is half of L2 clock cycle
+ */
 class SRAMTemplate[T <: Data]
 (
   gen: T, set: Int, way: Int = 1,
@@ -152,10 +159,9 @@ class SRAMTemplate[T <: Data]
     })
   }
 
-  // hold read data for SRAMs
   val rdata = (
-    if(clk_div_by_2){
-      DelayTwoCycle(mem_rdata, realRen)
+    if(clk_div_by_2) {
+      DelayTwoCycle(mem_rdata, realRen) // this holdRead as well
     } else if (holdRead) {
       HoldUnless(mem_rdata, RegNext(realRen))
     } else {

--- a/src/main/scala/coupledL2/utils/SRAMWrapper.scala
+++ b/src/main/scala/coupledL2/utils/SRAMWrapper.scala
@@ -6,7 +6,7 @@ import chisel3.util._
 class SRAMWrapper[T <: Data]
 (
   gen: T, set: Int, n: Int = 1,
-  clk_div_by_2: Boolean = false
+  clkDivBy2: Boolean = false
 ) extends Module {
 
   val io = IO(new Bundle() {
@@ -26,7 +26,7 @@ class SRAMWrapper[T <: Data]
     val ren = if(n == 1) true.B else i.U === r_sel
     val wen = if(n == 1) true.B else i.U === w_sel
     val sram = Module(new SRAMTemplate[T](
-      gen, innerSet, 1, singlePort = true, clk_div_by_2 = clk_div_by_2
+      gen, innerSet, 1, singlePort = true, clkDivBy2 = clkDivBy2
     ))
     sram.io.r.req.valid := io.r.req.valid && ren
     sram.io.r.req.bits.apply(r_setIdx)
@@ -37,7 +37,7 @@ class SRAMWrapper[T <: Data]
 
   val ren_vec_0 = VecInit(banks.map(_.io.r.req.fire))
   val ren_vec_1 = RegNext(ren_vec_0, 0.U.asTypeOf(ren_vec_0))
-  val ren_vec = if(clk_div_by_2){
+  val ren_vec = if(clkDivBy2){
     RegNext(ren_vec_1, 0.U.asTypeOf(ren_vec_0))
   } else ren_vec_1
 


### PR DESCRIPTION
# SRAM: implement real MCP2 logic

It must satisfy the following requirements:
1. no continuous SRAM reqs (need a gap cycle between two reqs)
2. input signals should hold for at least 2 cycles
3. sample SRAM rdata two cycles after read fire
4. **use enable to clock gate SRAM**, make sure each req is only
 sampled once

The process is as follows:
- s0: read fire (enable and input valid)
- s1: input holds, wait for SRAM rdata to be stable
- s2: rdata valid

Here we do not sample/RegEnable rdata in DataStorage, just sending it
 out as wire
GrantBuffer will RegEnable it

# Support MCP2 SRAM model
## （which returns rdata two cycles after read fire）
We set SRAM as external modules during V gen, then use `vlsi_mem_gen` script for SRAM generation.
Such procedure follows that of XiangShan repo.

SRAM in DataStorage uses suggestName to pass MCP2 info to mem-gen script
