### PR TITLE
Add CHI-Log

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 src/main/scala/coupledL2/Directory.scala @cailuoshan @linjuanZ
 src/main/scala/coupledL2/utils/ @cailuoshan @linjuanZ
 src/main/scala/coupledL2/prefetch/ @Maxpicca-Li
-src/main/scala/coupledL2/prefetch/ @wakafa1
 src/test/scala/ @Kumonda221-CrO3

--- a/scripts/view_chilog.sh
+++ b/scripts/view_chilog.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+db_path=$1
+shift
+
+while getopts ":x:w:l:" OPT; do
+  case $OPT in
+    x)
+      CHI_FIELD=", $OPTARG"
+      ;;
+    w)
+      CONDITION="where $OPTARG"
+      ;;
+    l)
+      LIMIT="limit $OPTARG"
+      ;;
+    \?)
+      echo "Unknown Option: -$OPTARG"
+      echo "Usage: $0 db_path [-x other_chi_fields] [-w condition] [-l limit]"
+      echo "Example:"
+      echo "       $0 /path/to/chisel.db -x TXNID -w 'ADDR=0x0' -l 10"
+      exit 1
+      ;;
+  esac
+done
+
+
+sqlite3 $db_path "select STAMP, SITE, ADDR, CHANNEL, OPCODE, DATA_0, DATA_1, DATA_2, DATA_3 $CHI_FIELD from CHILog $CONDITION $LIMIT" | sed 's/|/ /g' | awk --bignum '
+
+func chnstr(chn) {
+  split("TXREQ RXRSP RXDAT RXSNP TXRSP TXDAT", channels, " ");
+  return channels[chn + 1]
+}
+
+func opstr(chn, op) {
+  req[1] = "ReqLCrdReturn"
+  req[2] = "ReadShared"
+  req[3] = "ReadClean"
+  req[4] = "ReadOnce"
+  req[5] = "ReadNoSnp"
+  req[6] = "PCrdReturn"
+  req[8] = "ReadUnique"
+  req[9] = "CleanShared"
+  req[10] = "CleanInvalid"
+  req[11] = "MakeInvalid"
+  req[12] = "CleanUnique"
+  req[13] = "MakeUnique"
+  req[14] = "Evict"
+  req[21] = "DVMOp"
+  req[22] = "WriteEvictFull"
+  req[24] = "WriteCleanFull"
+  req[25] = "WriteUniquePtl"
+  req[26] = "WriteUniqueFull"
+  req[27] = "WriteBackPtl"
+  req[28] = "WriteBackFull"
+  req[29] = "WriteNoSnpPtl"
+  req[30] = "WriteNoSnpFull"
+  req[33] = "WriteUniqueFullStash"
+  req[34] = "WriteUniquePtlStash"
+  req[35] = "StashOnceShared"
+  req[36] = "StashOnceUnique"
+  req[37] = "ReadOnceCleanInvalid"
+  req[38] = "ReadOnceMakeInvalid"
+  req[39] = "ReadNotSharedDirty"
+  req[40] = "CleanSharedPersist"
+  req[41] = "AtomicStore_ADD"
+  req[42] = "AtomicStore_CLR"
+  req[43] = "AtomicStore_EOR"
+  req[44] = "AtomicStore_SET"
+  req[45] = "AtomicStore_SMAX"
+  req[46] = "AtomicStore_SMIN"
+  req[47] = "AtomicStore_UMAX"
+  req[48] = "AtomicStore_UMIN"
+  req[49] = "AtomicLoad_ADD"
+  req[50] = "AtomicLoad_CLR"
+  req[51] = "AtomicLoad_EOR"
+  req[52] = "AtomicLoad_SET"
+  req[53] = "AtomicLoad_SMAX"
+  req[54] = "AtomicLoad_SMIN"
+  req[55] = "AtomicLoad_UMAX"
+  req[56] = "AtomicLoad_UMIN"
+  req[57] = "AtomicSwap"
+  req[58] = "AtomicCompare"
+  req[59] = "PrefetchTgt"
+
+  resp[1] = "RespLCrdReturn"
+  resp[2] = "SnpResp"
+  resp[3] = "CompAck"
+  resp[4] = "RetryAck"
+  resp[5] = "Comp"
+  resp[6] = "CompDBIDResp"
+  resp[7] = "DBIDResp"
+  resp[8] = "PCrdGrant"
+  resp[9] = "ReadReceipt"
+  resp[10] = "SnpRespFwded"
+
+  snp[1] = "SnpLCrdReturn"
+  snp[2] = "SnpShared"
+  snp[3] = "SnpClean"
+  snp[4] = "SnpOnce"
+  snp[5] = "SnpNotSharedDirty"
+  snp[6] = "SnpUniqueStash"
+  snp[7] = "SnpMakeInvalidStash"
+  snp[8] = "SnpUnique"
+  snp[9] = "SnpCleanShared"
+  snp[10] = "SnpCleanInvalid"
+  snp[11] = "SnpMakeInvalid"
+  snp[12] = "SnpStashUnique"
+  snp[13] = "SnpStashShared"
+  snp[14] = "SnpDVMOp"
+  snp[18] = "SnpSharedFwd"
+  snp[19] = "SnpCleanFwd"
+  snp[20] = "SnpOnceFwd"
+  snp[21] = "SnpNotSharedDirtyFwd"
+  snp[24] = "SnpUniqueFwd"
+
+  data[1] = "DataLCrdReturn"
+  data[2] = "SnpRespData"
+  data[3] = "CopyBackWrData"
+  data[4] = "NonCopyBackWrData"
+  data[5] = "CompData"
+  data[6] = "SnpRespDataPtl"
+  data[7] = "SnpRespDataFwded"
+  data[8] = "WriteDataCancel"
+
+  ret = "Unknown OP"
+  switch(chn) {
+    case 0: # txreq
+      ret = req[op+1]
+      break;
+    case 1: # rxrsp
+      ret = resp[op+1]
+      break;
+    case 2: # rxdat
+      ret = data[op+1]
+      break;
+    case 3: # rxsnp
+      ret = snp[op+1]
+      break;
+    case 4: # txrsp
+      ret = resp[op+1]
+      break;
+    case 5: # txdat
+      ret = data[op+1]
+      break;
+  }
+  return ret
+}
+
+{
+  addr = $3
+  chn = $4
+  op = $5
+  data_1 = $6
+  data_2 = $7
+  data_3 = $8
+  data_4 = $9
+
+  $3 = sprintf("%lx(%ld)", addr, addr)
+  $4 = chnstr(chn)
+  $5 = sprintf("%-20s", opstr(chn, op))
+
+  if (chn == 2 || chn == 5) {
+    $6 = sprintf("%016lx", data_1)
+    $7 = sprintf("%016lx", data_2)
+    $8 = sprintf("%016lx", data_3)
+    $9 = sprintf("%016lx", data_4)
+  } else {
+    $6 = sprintf("%016s", "")
+    $7 = sprintf("%016s", "")
+    $8 = sprintf("%016s", "")
+    $9 = sprintf("%016s", "")
+  }
+}
+
+1                                   # print every line
+'
+
+
+
+# *** all CHI Fields ***
+# ID
+# RSVDC
+# TRACETAG
+# EXPCOMPACK
+# SNOOPME
+# LPID
+# SNPATTR
+# MEMATTR_EWA
+# MEMATTR_DEVICE
+# MEMATTR_CACHEABLE
+# MEMATTR_ALLOCATE
+# PCRDTYPE
+# ALLOWRETRY
+# LIKELYSHARED
+# NS
+# ADDR
+# SIZE
+# RETURNTXNID
+# STASHNIDVALID
+# RETURNNID
+# TXNID
+# SRCID
+# TGTID
+# QOS
+# DBID
+# FWDSTATE
+# RESP
+# RESPERR
+# DATA_0
+# DATA_1
+# DATA_2
+# DATA_3
+# BE
+# DATAID
+# CCID
+# HOMENID
+# RETTOSRC
+# DONOTGOTOSD
+# FWDTXNID
+# FWDNID
+# CHANNEL
+# ORDERING
+# OPCODE
+# STAMP
+# SITE

--- a/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
@@ -125,7 +125,7 @@ object CHILogger extends HasCHIMsgParameters {
     all_logs.zip(all_flits).map {
       case (log, flit) =>
         val data = flit.elements.filter(_._1 == "data")
-        log.opcode := {
+        log.data := {
           if (data.nonEmpty) data.head._2 else 0.U
         }
     }

--- a/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
@@ -35,42 +35,33 @@ class CHILogger(name: String, enable: Boolean)(implicit p: Parameters) extends M
 }
 
 object CHILogger extends HasCHIMsgParameters {
+  // packed_flit = true: just dump the whole flit as UInt
+  // packed_flit = false: separate every field
+  val packed_flit = false
+
   // ** !! gather all distinct fields from CHI bundles !! **
   val all_bundles = Seq(new CHIREQ, new CHIRSP, new CHIDAT, new CHISNP)
   val all_fields = all_bundles.map(_.elements).reduce(_.concat(_))
-
   // 1. ORDER is SQL key word, avoid it
   // 2. opcode width differs among channels, use Max of them
   val all_fields_sub = all_fields.removedAll(Seq("order", "opcode"))
   val all_fields_plus = ListMap.from(all_fields_sub) ++ ListMap("channel" -> UInt(3.W)) ++
     ListMap("ordering" -> UInt(3.W)) ++ ListMap("opcode" -> UInt(OPCODE_WIDTH.W))
 
+  val max_flit_width = all_bundles.map(ChannelIO(_).flit.getWidth).max
+  if(packed_flit) { println(s"max_flit_width: ${max_flit_width}") }
+  val all_fields_packed = ListMap("channel" -> UInt(3.W), "flitAll" -> UInt(max_flit_width.W))
+
+  val all_fields_final = {
+    if (packed_flit) all_fields_packed else all_fields_plus
+  }
+
   // use RecordMap to generate a Record from ListMap
-  val CHILogMessage = RecordMap(all_fields_plus)
+  val CHILogMessage = RecordMap(all_fields_final)
   val table = ChiselDB.createTable("CHILog", CHILogMessage, basicDB = true)
   // println(s"test: ${CHILogMessage.elements}")
 
   def track(out: PortIO, clock: Clock, reset: Reset)(name: String) = {
-    // only txreq and txsnp contains addr
-    // therefore we need to store addrs for their responses to match
-    val txreq_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
-    val rxsnp_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
-    val dbid_addrs = Reg(Vec((1 << DBID_WIDTH), UInt(ADDR_WIDTH.W)))
-
-    // Here are some cases:
-    // read (Normal): req(TxnID)->comp(TxnID); comp(DBID)->ack(TxnID)
-    // read (DMT): TODO
-    // read (DCT): RN0:req(TxnID)->RN1:SnpFwd(FwdTxnID)->RN0:CompData(TxnID); comp(DBID)->ack(TxnID)
-    //                                 SnpFwd(TxnID)   ->RN0:CompData(DBID) √
-    //                                 SnpFwd(TxnID)   ->ICN:SnpResp[Data]Fwded(TxnID)
-    // write (CopyBack): req(TxnID)->compDBID(TxnID); compDBID(DBID)->data(TxnID)
-    // write (NCb): TODO
-    // WriteNoSnp (combined resp): same as write (CopyBack)
-    // WriteNoSnp (separate resp): req(TxnID)->DBID(TxnID); DBID(DBID)->data(TxnID);
-    //                             req(TxnID)|DBID(DBID)->Comp(TxnID|DBID)
-    // dataless: same as read (Normal)
-    // Snoop: snp(TxnID)->resp(TxnID)
-
     val txreq = out.tx.req  // channel = 0
     val rxrsp = out.rx.rsp  // channel = 1
     val rxdat = out.rx.dat  // channel = 2
@@ -79,71 +70,101 @@ object CHILogger extends HasCHIMsgParameters {
     val txdat = out.tx.dat  // channel = 5
     val all_chns = Seq(txreq, rxrsp, rxdat, rxsnp, txrsp, txdat)
 
-    val txreq_flit = WireInit(0.U.asTypeOf(new CHIREQ))
-    val rxrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
-    val rxdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
-    val rxsnp_flit = WireInit(0.U.asTypeOf(new CHISNP))
-    val txrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
-    val txdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
-    val all_flits = Seq(txreq_flit, rxrsp_flit, rxdat_flit, rxsnp_flit, txrsp_flit, txdat_flit)
-
-    // ** parse flit into CHI bundles **
-    all_flits.zip(all_chns).map {
-      case (flit, chn) =>
-        var lsb = 0
-        flit.getElements.reverse.foreach { case e =>
-          e := chn.flit(lsb + e.asUInt.getWidth - 1, lsb).asTypeOf(e.cloneType)
-          lsb += e.asUInt.getWidth
-        }
-    }
-
     // ======== log ========
     val txreq_log, rxrsp_log, rxdat_log, rxsnp_log, txrsp_log, txdat_log = WireInit(0.U.asTypeOf(CHILogMessage))
     val all_logs = Seq(txreq_log, rxrsp_log, rxdat_log, rxsnp_log, txrsp_log, txdat_log)
 
-    all_logs.zip(all_flits).map {
-      case (log, flit) =>
-        log.elements.foreach{
-          case (name, data) =>
-            data := flit.elements.getOrElse(name, 0.U).asTypeOf(data)
-        }
+    if (!packed_flit) {
+      val txreq_flit = WireInit(0.U.asTypeOf(new CHIREQ))
+      val rxrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
+      val rxdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
+      val rxsnp_flit = WireInit(0.U.asTypeOf(new CHISNP))
+      val txrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
+      val txdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
+      val all_flits = Seq(txreq_flit, rxrsp_flit, rxdat_flit, rxsnp_flit, txrsp_flit, txdat_flit)
+
+      // ** parse flit into CHI bundles **
+      all_flits.zip(all_chns).map {
+        case (flit, chn) =>
+          var lsb = 0
+          flit.getElements.reverse.foreach { case e =>
+            e := chn.flit(lsb + e.asUInt.getWidth - 1, lsb).asTypeOf(e.cloneType)
+            lsb += e.asUInt.getWidth
+          }
+      }
+
+      // only txreq and txsnp contains addr
+      // therefore we need to store addrs for their responses to match
+      val txreq_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
+      val rxsnp_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
+      val dbid_addrs = Reg(Vec((1 << DBID_WIDTH), UInt(ADDR_WIDTH.W)))
+
+      // Here are some cases:
+      // read (Normal): req(TxnID)->comp(TxnID); comp(DBID)->ack(TxnID)
+      // read (DMT): TODO
+      // read (DCT): RN0:req(TxnID)->RN1:SnpFwd(FwdTxnID)->RN0:CompData(TxnID); comp(DBID)->ack(TxnID)
+      //                                 SnpFwd(TxnID)   ->RN0:CompData(DBID) √
+      //                                 SnpFwd(TxnID)   ->ICN:SnpResp[Data]Fwded(TxnID)
+      // write (CopyBack): req(TxnID)->compDBID(TxnID); compDBID(DBID)->data(TxnID)
+      // write (NCb): TODO
+      // WriteNoSnp (combined resp): same as write (CopyBack)
+      // WriteNoSnp (separate resp): req(TxnID)->DBID(TxnID); DBID(DBID)->data(TxnID);
+      //                             req(TxnID)|DBID(DBID)->Comp(TxnID|DBID)
+      // dataless: same as read (Normal)
+      // Snoop: snp(TxnID)->resp(TxnID)
+
+      all_logs.zip(all_flits).map {
+        case (log, flit) =>
+          log.elements.foreach {
+            case (name, data) =>
+              data := flit.elements.getOrElse(name, 0.U).asTypeOf(data)
+          }
+      }
+
+      // ** overwrite some special fields **
+      txreq_log.elements("ordering") := txreq_flit.order
+
+      // ** Address **
+      txreq_log.elements("addr") := txreq_flit.addr
+      // rxrsp may be Comp or CompDBIDResp (or RetryAck)
+      rxrsp_log.elements("addr") := txreq_addrs(rxrsp_flit.txnID)
+      // rxdat is CompData alone
+      rxdat_log.elements("addr") := txreq_addrs(rxdat_flit.txnID)
+
+      val rxsnp_addr_full = Cat(rxsnp_flit.addr, 0.U(3.W)) // Snp addr is [PA_MSB-1:3]
+      rxsnp_log.elements("addr") := rxsnp_addr_full
+      // txrsp may be CompAck or SnpResp[Fwded]
+      txrsp_log.elements("addr") := Mux(txrsp_flit.opcode === RSPOpcodes.CompAck, dbid_addrs(txrsp_flit.txnID), rxsnp_addrs(txrsp_flit.txnID))
+      // txdat may be SnpResp[Fwded]Data or CompData(DCT) CbWriteData (or NcbWriteData TODO)
+      txdat_log.elements("addr") := Mux(txdat_flit.opcode === DATOpcodes.CopyBackWrData, dbid_addrs(txdat_flit.txnID),
+        Mux(txdat_flit.opcode === DATOpcodes.CompData, rxsnp_addrs(txdat_flit.dbID), rxsnp_addrs(txdat_flit.txnID)))
+
+      // ======== record addrs at Reqs ========
+      when(txreq.flitv) {
+        txreq_addrs(txreq_flit.txnID) := txreq_flit.addr
+      }
+      when(rxsnp.flitv) {
+        rxsnp_addrs(rxsnp_flit.txnID) := rxsnp_addr_full
+      }
+      when(rxrsp.flitv && (rxrsp_flit.opcode === RSPOpcodes.CompDBIDResp || rxrsp_flit.opcode === RSPOpcodes.Comp)) {
+        val addr = txreq_addrs(rxrsp_flit.txnID)
+        dbid_addrs(rxrsp_flit.dbID) := addr
+      }
+      when(rxdat.flitv && rxdat_flit.opcode === DATOpcodes.CompData) {
+        val addr = txreq_addrs(rxdat_flit.txnID)
+        dbid_addrs(rxdat_flit.dbID) := addr
+      }
     }
-    // ** overwrite some special fields **
+    // ** packed flit **
+    else {
+      all_logs.zip(all_chns).map {
+        case (log, chn) =>
+          log.elements("flitAll") := chn.flit
+      }
+    }
+
     all_logs.zipWithIndex.map {
       case (log, i) => log.elements("channel") := i.U
-    }
-
-    txreq_log.elements("ordering") := txreq_flit.order
-
-    // ** Address **
-    txreq_log.elements("addr") := txreq_flit.addr
-    // rxrsp may be Comp or CompDBIDResp (or RetryAck)
-    rxrsp_log.elements("addr") := txreq_addrs(rxrsp_flit.txnID)
-    // rxdat is CompData alone
-    rxdat_log.elements("addr") := txreq_addrs(rxdat_flit.txnID)
-
-    val rxsnp_addr_full = Cat(rxsnp_flit.addr, 0.U(3.W)) // Snp addr is [PA_MSB-1:3]
-    rxsnp_log.elements("addr") := rxsnp_addr_full
-    // txrsp may be CompAck or SnpResp[Fwded]
-    txrsp_log.elements("addr") := Mux(txrsp_flit.opcode === RSPOpcodes.CompAck, dbid_addrs(txrsp_flit.txnID), rxsnp_addrs(txrsp_flit.txnID))
-    // txdat may be SnpResp[Fwded]Data or CompData(DCT) CbWriteData (or NcbWriteData TODO)
-    txdat_log.elements("addr") := Mux(txdat_flit.opcode === DATOpcodes.CopyBackWrData, dbid_addrs(txdat_flit.txnID),
-                                  Mux(txdat_flit.opcode === DATOpcodes.CompData, rxsnp_addrs(txdat_flit.dbID), rxsnp_addrs(txdat_flit.txnID)))
-
-    // ======== record addrs at Reqs ========
-    when(txreq.flitv) {
-      txreq_addrs(txreq_flit.txnID) := txreq_flit.addr
-    }
-    when(rxsnp.flitv) {
-      rxsnp_addrs(rxsnp_flit.txnID) := rxsnp_addr_full
-    }
-    when(rxrsp.flitv && (rxrsp_flit.opcode === RSPOpcodes.CompDBIDResp || rxrsp_flit.opcode === RSPOpcodes.Comp)) {
-      val addr = txreq_addrs(rxrsp_flit.txnID)
-      dbid_addrs(rxrsp_flit.dbID) := addr
-    }
-    when(rxdat.flitv && rxdat_flit.opcode === DATOpcodes.CompData) {
-      val addr = txreq_addrs(rxdat_flit.txnID)
-      dbid_addrs(rxdat_flit.dbID) := addr
     }
 
     // TODO: consider link active??

--- a/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
@@ -1,0 +1,159 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+ * Copyright (c) 2020-2021 Peng Cheng Laboratory
+ *
+ * XiangShan is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package coupledL2.tl2chi
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.Parameters
+import freechips.rocketchip.diplomacy._
+import utility.ChiselDB
+import CHIOpcode._
+
+class CHILogMessage extends Bundle with HasCHIMsgParameters  {
+  val channel = UInt(3.W)
+  val address = UInt(ADDR_WIDTH.W)
+  val opcode = UInt(OPCODE_WIDTH.W)
+
+  // TODO: just pack everything into here for now, consider split? by script when anaylze
+  // Since DB entry format must be unified, we just use UInt(widestWidth.W) for all channels
+  val flit = UInt(400.W) // TODOTODO! check width
+
+  // TODO: .elements.filterNot(_._1 == "data")
+  // this can be used to exclude data from flit
+}
+
+class CHILogger(name: String, enable: Boolean)(implicit p: Parameters) extends Module {
+  val io = IO(new Bundle() {
+    val up = Flipped(new PortIO)
+    val down = new PortIO
+  })
+  io.down <> io.up
+  CHILogger.track(io.down, this.clock, this.reset)(name)
+  dontTouch(io) // TODOTODO
+}
+
+object CHILogger extends HasCHIMsgParameters {
+
+  val table = ChiselDB.createTable("CHILog", new CHILogMessage, basicDB = true)
+
+  def track(out: PortIO, clock: Clock, reset: Reset)(name: String) = {
+    // only txreq and txsnp contains addr
+    // therefore we need to store addrs for their responses to match
+    val txreq_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
+    val rxsnp_addrs = Reg(Vec((1 << TXNID_WIDTH), UInt(ADDR_WIDTH.W)))
+    val dbid_addrs = Reg(Vec((1 << DBID_WIDTH), UInt(ADDR_WIDTH.W)))
+    // Here are some cases:
+    // read (Normal): req(TxnID)->comp(TxnID); comp(DBID)->ack(TxnID)
+    // read (DMT): TODO
+    // read (DCT): TODO
+    // write (CopyBack): req(TxnID)->compDBID(TxnID); compDBID(DBID)->data(TxnID)
+    // write (NCb): TODO
+    // WriteNoSnp (combined resp): same as write (CopyBack)
+    // WriteNoSnp (separate resp): TODO
+    // dataless: same as read (Normal)
+    // Snoop: snp(TxnID)->resp(TxnID)
+
+    val txreq = out.tx.req  // channel = 0
+    val rxrsp = out.rx.rsp  // channel = 1
+    val rxdat = out.rx.dat  // channel = 2
+    val rxsnp = out.rx.snp  // channel = 3
+    val txrsp = out.tx.rsp  // channel = 4
+    val txdat = out.tx.dat  // channel = 5
+    val all_chns = Seq(txreq, rxrsp, rxdat, rxsnp, txrsp, txdat)
+
+    val txreq_flit = WireInit(0.U.asTypeOf(new CHIREQ))
+    val rxrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
+    val rxdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
+    val rxsnp_flit = WireInit(0.U.asTypeOf(new CHISNP))
+    val txrsp_flit = WireInit(0.U.asTypeOf(new CHIRSP))
+    val txdat_flit = WireInit(0.U.asTypeOf(new CHIDAT))
+    val all_flits = Seq(txreq_flit, rxrsp_flit, rxdat_flit, rxsnp_flit, txrsp_flit, txdat_flit)
+    // TODO:? does this module work for txreq/txrsp/txdat?
+
+    all_flits.zip(all_chns).map {
+      case (flit, chn) =>
+        var lsb = 0
+        flit.getElements.reverse.foreach { case e =>
+          e := chn.flit(lsb + e.asUInt.getWidth - 1, lsb).asTypeOf(e.cloneType)
+          lsb += e.asUInt.getWidth
+        }
+    }
+    
+    val txreq_log, rxrsp_log, rxdat_log, rxsnp_log, txrsp_log, txdat_log = WireInit(0.U.asTypeOf(new CHILogMessage))
+    val all_logs = Seq(txreq_log, rxrsp_log, rxdat_log, rxsnp_log, txrsp_log, txdat_log)
+
+    // ======== log entry assignment ========
+    all_logs.zipWithIndex.map {
+      case (log, i) => log.channel := i.U
+    }
+
+    all_logs.zip(all_flits).map {
+      case (log, flit) => log.opcode := flit.elements.filter(_._1 == "opcode").head._2
+    }
+
+
+    txreq_log.address := txreq_flit.addr
+    // rxrsp may be Comp or CompDBIDResp (or RetryAck)
+    rxrsp_log.address := txreq_addrs(rxrsp_flit.txnID)
+    // rxdat is CompData alone
+    rxdat_log.address := txreq_addrs(rxdat_flit.txnID)
+
+    val rxsnp_addr_full = Cat(rxsnp_flit.addr, 0.U(3.W)) // Snp addr is [PA_MSB-1:3]
+    rxsnp_log.address := rxsnp_addr_full
+    // txrsp may be SnpResp or CompAck (or SnpRespFwded: TODO)
+    txrsp_log.address := Mux(txrsp_flit.opcode === RSPOpcodes.CompAck, dbid_addrs(txrsp_flit.txnID), rxsnp_addrs(txrsp_flit.txnID))
+    // txdat may be SnpRespData or CbWriteData (or NcbWriteData or SnpRespDataFwded:TODO)
+    txdat_log.address := Mux(txdat_flit.opcode === DATOpcodes.CopyBackWrData, dbid_addrs(txdat_flit.txnID), rxsnp_addrs(txdat_flit.txnID))
+
+    all_logs.zip(all_chns).map {
+      case (log, chn) => log.flit := chn.flit
+    }
+
+    // ======== record addrs at Reqs ========
+    when(txreq.flitv) {
+      txreq_addrs(txreq_flit.txnID) := txreq_flit.addr
+    }
+    when(rxsnp.flitv) {
+      rxsnp_addrs(rxsnp_flit.txnID) := rxsnp_addr_full
+    }
+    // TODO: record CompData/Comp for CompAck?
+    when(rxrsp.flitv && (rxrsp_flit.opcode === RSPOpcodes.CompDBIDResp || rxrsp_flit.opcode === RSPOpcodes.Comp)) {
+      val addr = txreq_addrs(rxrsp_flit.txnID)
+      dbid_addrs(rxrsp_flit.dbID) := addr
+    }
+    when(rxdat.flitv && rxdat_flit.opcode === DATOpcodes.CompData) {
+      val addr = txreq_addrs(rxdat_flit.txnID)
+      dbid_addrs(rxdat_flit.dbID) := addr
+    }
+
+    // TODO: only record certain reqs? or keep them all (CompAck, PCrdGrant)
+
+    // TODO: link active??
+    table.log(txreq_log, txreq.flitv, name, clock, reset)
+    table.log(rxrsp_log, rxrsp.flitv, name, clock, reset)
+    table.log(rxdat_log, rxdat.flitv, name, clock, reset)
+    table.log(rxsnp_log, rxsnp.flitv, name, clock, reset)
+    table.log(txrsp_log, txrsp.flitv, name, clock, reset)
+    table.log(txdat_log, txdat.flitv, name, clock, reset)
+
+  }
+
+  def apply(name: String, enable: Boolean = true)(implicit p: Parameters) = {
+    val logger = Module(new CHILogger(name, enable))
+    logger
+  }
+}


### PR DESCRIPTION
for CHILog:
- Log will record every distinct field in CHIREQ, CHIRSP, CHIDAT, CHISNP
- Addresses are saved at TXREQ/RXSNP
- Future responses will use txnID/DBID to match for the corresponding addr
- Support dump every field separately, or just dump the entire flit as UInt

A script `view_chilog.sh` will be used to parse CHILog from db file
```
> ./scripts/view_chilog.sh chiseldb.db -l 16 -w "ADDR=0x18000"
132 L3_L2[0] 18000(98304) TXREQ ReadUnique
132 L3_L2[1] 18000(98304) TXREQ MakeUnique
134 L3_L2[0] 18000(98304) RXSNP SnpMakeInvalid
140 L3_L2[0] 18000(98304) TXRSP SnpResp
142 L3_L2[1] 18000(98304) RXRSP Comp
146 L3_L2[1] 18000(98304) TXRSP CompAck
150 L3_L2[1] 18000(98304) RXSNP SnpUnique
164 L3_L2[1] 18000(98304) TXDAT SnpRespData          5c94b0fed01d7ad4 bdd4b45007188a1b fd2ea9ae0f3fb07e 5c0119a2be27a761
165 L3_L2[1] 18000(98304) TXDAT SnpRespData          36d8c9cc3ceb562b c8300b4ac9a10efb 5a0cd5371fdec222 d39e4ffd25da7ca9
167 L3_L2[0] 18000(98304) RXDAT CompData             5c94b0fed01d7ad4 bdd4b45007188a1b fd2ea9ae0f3fb07e 5c0119a2be27a761
168 L3_L2[0] 18000(98304) RXDAT CompData             36d8c9cc3ceb562b c8300b4ac9a10efb 5a0cd5371fdec222 d39e4ffd25da7ca9
171 L3_L2[0] 18000(98304) TXRSP CompAck
404 L3_L2[0] 18000(98304) TXREQ WriteBackFull
456 L3_L2[0] 18000(98304) RXRSP CompDBIDResp
463 L3_L2[0] 18000(98304) TXDAT CopyBackWrData       300020c6653d58a8 2f9e1d895a98bc02 f1b735d1521e0099 69225c2ee80b6425
464 L3_L2[0] 18000(98304) TXDAT CopyBackWrData       499ed361a91846ee 690b7699ea35d54c f1305ba56090e813 f1bfbd899a44d172