### PR TITLE
MSHR: fix bug when SnpRespFwded nestedwb the same MSHR

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1017,18 +1017,18 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module {
     when (io.nestedwb.c_set_dirty) {
       meta.dirty := true.B
     }
-    when (io.nestedwb.b_inv_dirty) {
+    when (io.nestedwb.b_inv_dirty && req.fromA) {
       meta.dirty := false.B
       meta.state := INVALID
       probeDirty := false.B
     }
   }
   when (nestedwb_hit_match) {
-    when (io.nestedwb.b_toB.get) {
+    when (io.nestedwb.b_toB.get && req.fromA) {
       meta.state := Mux(meta.state >= BRANCH, BRANCH, INVALID)
       meta.dirty := false.B
     }
-    when (io.nestedwb.b_toN.get) {
+    when (io.nestedwb.b_toN.get && req.fromA) {
       meta.state := INVALID
       dirResult.hit := false.B
       meta.dirty := false.B


### PR DESCRIPTION
Each SnpFwd request is allocated an MSHR entry to return SnpResp[Data]Fwded and CompData sequentially. When SnpResp[Data]Fwded reaches stage s3 of MainPipe, it should check whether there are MSHRs with the same addr and write back the latest meta onto the nested MSHR if there is any. If CompData of the origin SnpFwd has not been sent out yet, SnpResp[Data]Fwded might nested write back to itself, which causes the MSHR to stuck on `w_replResp`.