### PR TITLE
TL2CHICoupledL2, MSHR: fix RXRSP timing path

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -372,3 +372,29 @@ class L2ToL1TlbIO(nRespDups: Int = 1)(implicit p: Parameters) extends L2Bundle{
   val resp = Flipped(DecoupledIO(new L2TlbResp(nRespDups)))
   val pmp_resp = Flipped(new PMPRespBundle())
 }
+
+class PCrdGrantMatcherIO(val numPorts: Int) extends Bundle {
+  val io_waitPCrdInfo = Input(Vec(numPorts, new Bundle {
+    val valid = Bool()
+    val srcID = UInt(7.W)
+    val pCrdType = UInt(4.W)
+  }))
+  val rxrsp = Input(new Bundle {
+    val bits = new Bundle {
+      val srcID = UInt(7.W)
+      val pCrdType = UInt(4.W)
+    }
+  })
+  val isPCrdGrant = Input(Bool())
+  val matchPCrdGrant = Output(UInt(numPorts.W))
+}
+
+class PCrdGrantMatcher(val numPorts: Int) extends Module {
+  val io = IO(new PCrdGrantMatcherIO(numPorts))
+
+  io.matchPCrdGrant := VecInit(io.io_waitPCrdInfo.map { p =>
+    p.valid && io.isPCrdGrant &&
+    p.srcID === io.rxrsp.bits.srcID &&
+    p.pCrdType === io.rxrsp.bits.pCrdType
+  }).asUInt
+}

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -61,7 +61,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     val nestedwbData = Output(Bool())
     val aMergeTask = Flipped(ValidIO(new TaskBundle))
     val replResp = Flipped(ValidIO(new ReplacerResult))
-    val pCamPri = Input(Bool())
+    val pCrdPri = Input(Bool())
     val waitPCrdInfo = Output(new PCrdInfo)
   })
 
@@ -889,13 +889,10 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       pcrdtype := rxrsp.bits.pCrdType.getOrElse(0.U)
       gotRetryAck := true.B
     }
-    when (rxrsp.bits.chiOpcode.get === PCrdGrant) {
-      state.s_reissue.get := false.B
-      gotPCrdGrant := true.B
-    }
   }
- // when there is this type of pCredit in pCam -> reissue
-  when (io.pCamPri) {
+
+  // when rxrsp is PCrdGrant
+  when (io.pCrdPri) {
     state.s_reissue.get := false.B
     gotPCrdGrant := true.B
   }

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -91,6 +91,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
 
     /* to Slice Top for pCrd info.*/
     val waitPCrdInfo  = Output(Vec(mshrsAll, new PCrdInfo))
+    val matchPCrdInfo = Input(UInt(mshrsAll.W))
 })
 
   /*MSHR allocation pointer gen -> to Mainpipe*/
@@ -124,18 +125,18 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
    3. use Round-Robin arbiter if multi-entry match
    */
   val isPCrdGrant = io.resps.rxrsp.valid && (io.resps.rxrsp.respInfo.chiOpcode.get === PCrdGrant)
+  val isPCrdGrantReg = RegNext(isPCrdGrant)
   val waitPCrdInfo  = Wire(Vec(mshrsAll, new PCrdInfo))
   val timeOutPri = VecInit(Seq.fill(16)(false.B))
   val timeOutSel = WireInit(false.B)
   val pCrdPri = VecInit(Seq.fill(16)(false.B))
   val pArb = Module(new RRArbiter(UInt(), mshrsAll))
 
-  val matchPCrdGrant = VecInit(waitPCrdInfo.map(p =>
-      isPCrdGrant && p.valid &&
-      p.srcID.get === io.resps.rxrsp.respInfo.srcID.get &&
-      p.pCrdType.get === io.resps.rxrsp.respInfo.pCrdType.get
-  ))
-
+  val matchPCrdGrantPre = VecInit(pCrdPri.zip(io.matchPCrdInfo.asBools.map(_ & io.resps.rxrsp.valid)).map{
+    case(a,b) => !a & b
+  })
+  val  matchPCrdGrant = RegNext(matchPCrdGrantPre)
+   
   pArb.io.in.zipWithIndex.foreach {
     case (in, i) =>
       in.valid := matchPCrdGrant(i)
@@ -145,7 +146,6 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
 
   val pCrdOH = VecInit(UIntToOH(pArb.io.chosen).asBools)
   val pCrdFixPri = VecInit(pCrdOH zip matchPCrdGrant map {case(a,b) => a && b})
-//val pCrdFixPri = VecInit(PriorityEncoderOH(matchPCrdGrantReg)) //fix priority arbiter
 
   // timeout protect
   val counter = RegInit(VecInit(Seq.fill(mshrsAll)(0.U((log2Ceil(mshrsAll)+1).W))))
@@ -225,7 +225,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
       m.io.resps.rxdat.valid := m.io.status.valid && io.resps.rxdat.valid && io.resps.rxdat.mshrId === i.U
       m.io.resps.rxdat.bits := io.resps.rxdat.respInfo
 
-      m.io.resps.rxrsp.valid := (m.io.status.valid && io.resps.rxrsp.valid && !isPCrdGrant && io.resps.rxrsp.mshrId === i.U) || (isPCrdGrant && pCrdPri(i))
+      m.io.resps.rxrsp.valid := m.io.status.valid && io.resps.rxrsp.valid && !isPCrdGrant && (io.resps.rxrsp.mshrId === i.U)
       m.io.resps.rxrsp.bits := io.resps.rxrsp.respInfo
 
       m.io.replResp.valid := io.replResp.valid && io.replResp.bits.mshrId === i.U
@@ -236,10 +236,10 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
       m.io.aMergeTask.valid := io.aMergeTask.valid && io.aMergeTask.bits.id === i.U
       m.io.aMergeTask.bits := io.aMergeTask.bits.task
 
-      waitPCrdInfo(i) := m.io.waitPCrdInfo 
-      m.io.pCamPri := 0.U /*(pCamPri === i.U) && waitPCrdInfo(i).valid*/
+      waitPCrdInfo(i) := m.io.waitPCrdInfo
+      m.io.pCrdPri := isPCrdGrantReg && pCrdPri(i)
   }
-  /* Reserve 1 entry for SinkB */
+  /* mshrc -> L2Top to wait pCrd */
   io.waitPCrdInfo <> waitPCrdInfo
 
   /* Reserve 1 entry for SinkB */

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -34,6 +34,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
     override val out: OuterBundle = new OuterBundle
   })
   val io_waitPCrdInfo = IO(Output(Vec(mshrsAll, new PCrdInfo)))
+  val io_matchPCrdInfo = IO(Input(UInt(mshrsAll.W)))
   val io_msStatus = topDownOpt.map(_ => IO(Vec(mshrsAll, ValidIO(new MSHRStatus))))
 
   /* Upwards TileLink-related modules */
@@ -176,7 +177,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
 
   /* to Slice Top for pCrd info.*/
   io_waitPCrdInfo <> mshrCtl.io.waitPCrdInfo
-
+  io_matchPCrdInfo <> mshrCtl.io.matchPCrdInfo
   /* IO Connection */
   io.l1Hint <> mainPipe.io.l1Hint
   topDownOpt.foreach (

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -36,6 +36,7 @@ abstract class TL2CHIL2Module(implicit val p: Parameters) extends Module
   with HasCoupledL2Parameters
   with HasCHIMsgParameters
 
+
 class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
 
   val addressRange = AddressSet(0x00000000L, 0xfffffffffL).subtract(AddressSet(0x0L, 0x7fffffffL)) // TODO: parameterize this
@@ -155,6 +156,8 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         val rxrspIsMMIO = rxrsp.bits.txnID.head(1).asBool
         val isPCrdGrant = rxrsp.valid && (rxrsp.bits.opcode === PCrdGrant)
         val pArb = Module(new RRArbiter(UInt(), banks))
+        val pMatch = VecInit(Seq.fill(banks)(Module(new PCrdGrantMatcher(mshrsAll)).io))
+        val pCrdSliceID = Wire(UInt(log2Ceil(banks).W))
         /*
         when PCrdGrant, give credit to one Slice that:
         1. got RetryAck and not Reissued
@@ -162,22 +165,34 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         3. use Round-Robin arbiter if multi-Slice match
         */
         val matchPCrdGrant = Wire(Vec(banks, UInt(mshrsAll.W)))
+        val validCounts = Wire(Vec(banks, UInt(log2Ceil(mshrsAll+1).W)))
         slices.zipWithIndex.foreach { case (s, i) =>
-          matchPCrdGrant(i) := VecInit(s.io_waitPCrdInfo.map(p =>
-            p.valid && isPCrdGrant &&
-            p.srcID.get === rxrsp.bits.srcID &&
-            p.pCrdType.get === rxrsp.bits.pCrdType
-          )).asUInt
+          pMatch(i).io_waitPCrdInfo := s.io_waitPCrdInfo
+          pMatch(i).rxrsp.bits.srcID := rxrsp.bits.srcID
+          pMatch(i).rxrsp.bits.pCrdType := rxrsp.bits.pCrdType
+          pMatch(i).isPCrdGrant := isPCrdGrant
+
+          matchPCrdGrant(i) := pMatch(i).matchPCrdGrant
+          s.io_matchPCrdInfo := matchPCrdGrant(i)
+          validCounts(i) := PopCount(s.io_waitPCrdInfo.map(_.valid))
         }
+
         val pCrdIsWait = VecInit(matchPCrdGrant.map(_.asUInt.orR)).asUInt
+        val pCrdSliceIDOH = UIntToOH(pCrdSliceID)
+        val onlyValidraw = Cat(validCounts.map(count => count === 1.U)).asUInt
+        val onlyValid = Reverse(onlyValidraw)
+        val pCrdSliceHit = pCrdSliceIDOH & pCrdIsWait & onlyValid
+        val pCrdCancel = RegNext(pCrdSliceHit) & onlyValid
 
         pArb.io.in.zipWithIndex.foreach {
           case (in, i) =>
-            in.valid := pCrdIsWait(i)
+            in.valid := pCrdIsWait(i) && !pCrdCancel(i)
             in.bits := 0.U
         }
         pArb.io.out.ready := true.B
-        val pCrdSliceID = pArb.io.chosen 
+        pCrdSliceID := pArb.io.chosen
+
+
         val rxrspSliceID = Mux(isPCrdGrant, pCrdSliceID, getSliceID(rxrsp.bits.txnID))
         slices.zipWithIndex.foreach { case (s, i) =>
           s.io.out.rx.rsp.valid := rxrsp.valid && rxrspSliceID === i.U && !rxrspIsMMIO


### PR DESCRIPTION
a. Common:  add pMatch module instance instead of logic for FloorPlan identification
b. MSHR: pCrdGrant handles in next cycle of rxrsp.valid, other operations are in rxrsp.valid cycle 
c. MSHRCtrl: pMatch result registered to fix timing 
d. Slice: add interface to send pMatch result from TL2CHICoupledL2 to MSHRCtrl 
e. TL2CHICoupledL2: handle pWaitInfo residual effetcts because handles pCrdGrant in next cycle of rxrsp.valid
