### PR TITLE
Fix the simulation timeout caused by x-state ready signal

### DIFF
--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -22,7 +22,7 @@ import chisel3.util._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tilelink.TLMessages._
 import org.chipsalliance.cde.config.Parameters
-import utility.{MemReqSource, XSPerfAccumulate}
+import utility.{MemReqSource, XSPerfAccumulate, RRArbiterInit}
 
 class PipeBufferResp(implicit p: Parameters) extends L2Bundle {
   val data = Vec(beatSize, UInt((beatBytes * 8).W))
@@ -54,7 +54,7 @@ class SinkC(implicit p: Parameters) extends L2Module {
   val dataValids = VecInit(beatValids.map(_.asUInt.orR)).asUInt
   val taskBuf = RegInit(VecInit(Seq.fill(bufBlocks)(0.U.asTypeOf(new TaskBundle))))
   val taskValids = RegInit(VecInit(Seq.fill(bufBlocks)(false.B)))
-  val taskArb = Module(new RRArbiter(new TaskBundle, bufBlocks))
+  val taskArb = Module(new RRArbiterInit(new TaskBundle, bufBlocks))
   val bufValids = taskValids.asUInt | dataValids
 
   val full = bufValids.andR

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -128,7 +128,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
   val timeOutPri = VecInit(Seq.fill(16)(false.B))
   val timeOutSel = WireInit(false.B)
   val pCrdPri = VecInit(Seq.fill(16)(false.B))
-  val pArb = Module(new RRArbiter(UInt(), mshrsAll))
+  val pArb = Module(new RRArbiterInit(UInt(), mshrsAll))
 
   val matchPCrdGrant = VecInit(waitPCrdInfo.map(p =>
       isPCrdGrant && p.valid &&

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -19,7 +19,7 @@ package coupledL2.tl2chi
 
 import chisel3._
 import chisel3.util._
-import utility.{FastArbiter, Pipeline, ParallelPriorityMux, RegNextN}
+import utility.{FastArbiter, Pipeline, ParallelPriorityMux, RegNextN, RRArbiterInit}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tilelink.TLMessages._
@@ -154,7 +154,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         val rxrsp = Wire(DecoupledIO(new CHIRSP))
         val rxrspIsMMIO = rxrsp.bits.txnID.head(1).asBool
         val isPCrdGrant = rxrsp.valid && (rxrsp.bits.opcode === PCrdGrant)
-        val pArb = Module(new RRArbiter(UInt(), banks))
+        val pArb = Module(new RRArbiterInit(UInt(), banks))
         /*
         when PCrdGrant, give credit to one Slice that:
         1. got RetryAck and not Reissued


### PR DESCRIPTION
In the TL2CHICoupledL2 module, when a PCrdGrant response is received, the corresponding response is directed to a specific slice based on the pArb's chosen signal. `pArb` is an RRArbiter object, and there are uninitialized registers in the RRArbiter. In VCS simulation, these uninitialized registers can lead to an x-state, which propagates to the `chosen` signal, then to the `pCrdSliceID` signal, and eventually to the `ready` signal on the rxrsp channel, causing the simulation to hang.

The solution is to replace the RRArbiter in TL2CHICoupledL2 with RRArbiterInit. This commit also replaces other instances of RRArbiter with RRArbiterInit in CoupledL2