### PR TITLE
feat: use dual-port SRAM in Queue for large queues `(TXDAT/GrantBuffer/SourceC)`

### DIFF
--- a/src/main/scala/coupledL2/GrantBuffer.scala
+++ b/src/main/scala/coupledL2/GrantBuffer.scala
@@ -112,7 +112,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
 
   // val grantQueue = Module(new Queue(new GrantQueueTask(), entries = mshrsAll))
   // Use customized SRAM: dual_port, max 256bits:
-  val grantQueue = Module(new Queue_SRAM(new GrantQueueTask(), entries = mshrsAll, useSyncReadMem = true))
+  val grantQueue = Module(new Queue(new GrantQueueTask(), entries = mshrsAll))
   val grantQueueData0 = Module(new Queue_SRAM(new GrantQueueData(), entries = mshrsAll, useSyncReadMem = true))
   val grantQueueData1 = Module(new Queue_SRAM(new GrantQueueData(), entries = mshrsAll, useSyncReadMem = true))
 

--- a/src/main/scala/coupledL2/GrantBuffer.scala
+++ b/src/main/scala/coupledL2/GrantBuffer.scala
@@ -24,6 +24,7 @@ import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tilelink.TLMessages._
 import coupledL2.prefetch.PrefetchResp
+import coupledL2.utils.Queue_SRAM
 
 // record info of those with Grant sent, yet GrantAck not received
 // used to block Probe upwards
@@ -37,10 +38,17 @@ class TaskWithData(implicit p: Parameters) extends L2Bundle {
   val data = new DSBlock()
 }
 
-class GrantQueueTask(implicit p: Parameters) extends L2Bundle {
+/*class GrantQueueTask(implicit p: Parameters) extends L2Bundle {
   val task = new TaskBundle()
   val data = new DSBlock()
   val grantid = UInt(mshrBits.W)
+}*/
+class GrantQueueTask(implicit p: Parameters) extends L2Bundle {
+  val task = new TaskBundle()
+  val grantid = UInt(mshrBits.W)
+}
+class GrantQueueData(implicit p: Parameters) extends L2Bundle {
+  val data = new DSBeat()
 }
 
 // 1. Communicate with L1
@@ -102,7 +110,12 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
 //    (next_beat, next_beatsOH)
 //  }
 
-  val grantQueue = Module(new Queue(new GrantQueueTask(), entries = mshrsAll))
+  // val grantQueue = Module(new Queue(new GrantQueueTask(), entries = mshrsAll))
+  // Use customized SRAM: dual_port, max 256bits:
+  val grantQueue = Module(new Queue_SRAM(new GrantQueueTask(), entries = mshrsAll, useSyncReadMem = true))
+  val grantQueueData0 = Module(new Queue_SRAM(new GrantQueueData(), entries = mshrsAll, useSyncReadMem = true))
+  val grantQueueData1 = Module(new Queue_SRAM(new GrantQueueData(), entries = mshrsAll, useSyncReadMem = true))
+
   val inflightGrant = RegInit(VecInit(Seq.fill(grantBufInflightSize){
     0.U.asTypeOf(Valid(new InflightGrantEntry))
   }))
@@ -149,8 +162,12 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   grantQueue.io.enq.bits.task := Mux(io.d_task.bits.task.mergeA, mergeAtask, io.d_task.bits.task)
   grantQueue.io.enq.bits.task.isKeyword.foreach(_ := grantQueue_enq_isKeyword)
   //grantQueue.io.enq.bits.task.isKeyword.foreach(_ := io.d_task.bits.task.isKeyword.getOrElse(false.B))
-  grantQueue.io.enq.bits.data := io.d_task.bits.data
   grantQueue.io.enq.bits.grantid := inflight_insertIdx
+  val enqData = io.d_task.bits.data.asTypeOf(Vec(beatSize, new DSBeat))
+  grantQueueData0.io.enq.valid := grantQueue.io.enq.valid
+  grantQueueData0.io.enq.bits.data := enqData(0)
+  grantQueueData1.io.enq.valid := grantQueue.io.enq.valid
+  grantQueueData1.io.enq.bits.data := enqData(1)
   io.d_task.ready := true.B // GrantBuf should always be ready
 
   val grantQueueCnt = grantQueue.io.count
@@ -162,8 +179,8 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   val deqValid = grantQueue.io.deq.valid
   val deqTask = grantQueue.io.deq.bits.task
  // val deqTask.isKeyword.foreach(_ := grantQueue.io.deq.bits.task.isKeyword)
-  val deqData = grantQueue.io.deq.bits.data.asTypeOf(Vec(beatSize, new DSBeat))
   val deqId   = grantQueue.io.deq.bits.grantid
+  val deqData = VecInit(Seq(grantQueueData0.io.deq.bits.data, grantQueueData1.io.deq.bits.data))
 
   // grantBuf: to keep the remaining unsent beat of GrantData
   val grantBufValid = RegInit(false.B)
@@ -174,6 +191,8 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   }))
 
   grantQueue.io.deq.ready := io.d.ready && !grantBufValid
+  grantQueueData0.io.deq.ready := grantQueue.io.deq.ready
+  grantQueueData1.io.deq.ready := grantQueue.io.deq.ready
 
   // if deqTask has data, send the first beat directly and save the remaining beat in grantBuf
   when(deqValid && io.d.ready && !grantBufValid && deqTask.opcode(0)) {

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -21,7 +21,7 @@ import chisel3._
 import chisel3.util._
 import utility._
 import org.chipsalliance.cde.config.Parameters
-import coupledL2.{TaskWithData, TaskBundle}
+import coupledL2.{TaskWithData, TaskBundle, DSBlock, DSBeat}
 import coupledL2.utils.Queue_SRAM
 
 class TXDATBlockBundle(implicit p: Parameters) extends TXBlockBundle {

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -46,7 +46,7 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module {
 
   // TODO: an mshrsAll-entry queue is too much, evaluate for a proper size later
   // Use customized SRAM: dual_port, max 256bits:
-  val queue = Module(new Queue_SRAM(new TaskBundle(), entries = mshrsAll, flow = true, useSyncReadMem = true))
+  val queue = Module(new Queue(new TaskBundle(), entries = mshrsAll, flow = true))
   val queueData0 = Module(new Queue_SRAM(new DSBeat(), entries = mshrsAll, flow = true, useSyncReadMem = true))
   val queueData1 = Module(new Queue_SRAM(new DSBeat(), entries = mshrsAll, flow = true, useSyncReadMem = true))
   queue.io.enq.valid := io.in.valid

--- a/src/main/scala/coupledL2/tl2tl/SourceC.scala
+++ b/src/main/scala/coupledL2/tl2tl/SourceC.scala
@@ -138,7 +138,7 @@ class SourceC(implicit p: Parameters) extends L2Module {
 
   // We must keep SourceC FIFO, so a queue is used
   // Use customized SRAM: dual_port, max 256bits:
-  val queue = Module(new Queue_SRAM(new TaskBundle(), entries = mshrsAll, flow = true, useSyncReadMem = true))
+  val queue = Module(new Queue(new TaskBundle(), entries = mshrsAll, flow = true))
   val queueData0 = Module(new Queue_SRAM(new DSBeat(), entries = mshrsAll, flow = true, useSyncReadMem = true))
   val queueData1 = Module(new Queue_SRAM(new DSBeat(), entries = mshrsAll, flow = true, useSyncReadMem = true))
   queue.io.enq.valid := io.in.valid

--- a/src/main/scala/coupledL2/utils/Queue_SRAM.scala
+++ b/src/main/scala/coupledL2/utils/Queue_SRAM.scala
@@ -46,20 +46,14 @@ class Queue_SRAM[T <: Data](
                         val flow:           Boolean = false,
                         val useSyncReadMem: Boolean = false,
                         val hasFlush:       Boolean = false
-                      )(
-                        implicit compileOptions: chisel3.CompileOptions)
+                      )()
   extends Module() {
   require(entries > -1, "Queue must have non-negative number of entries")
   require(entries != 0, "Use companion object Queue.apply for zero entries")
-  val genType = if (compileOptions.declaredTypeMustBeUnbound) {
-    requireIsChiselType(gen)
-    gen
+  val genType = if (DataMirror.internal.isSynthesizable(gen)) {
+    chiselTypeOf(gen)
   } else {
-    if (DataMirror.internal.isSynthesizable(gen)) {
-      chiselTypeOf(gen)
-    } else {
-      gen
-    }
+    gen
   }
 
   val io = IO(new QueueIO(genType, entries, hasFlush))

--- a/src/main/scala/coupledL2/utils/Queue_SRAM.scala
+++ b/src/main/scala/coupledL2/utils/Queue_SRAM.scala
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/** Wrappers for ready-valid (Decoupled) interfaces and associated circuit generators using them.
+ */
+
+package coupledL2.utils
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.{requireIsChiselType, Direction}
+import chisel3.reflect.DataMirror
+
+import scala.annotation.nowarn
+
+/** A hardware module implementing a Queue
+ * @param gen The type of data to queue
+ * @param entries The max number of entries in the queue
+ * @param pipe True if a single entry queue can run at full throughput (like a pipeline). The ''ready'' signals are
+ * combinationally coupled.
+ * @param flow True if the inputs can be consumed on the same cycle (the inputs "flow" through the queue immediately).
+ * The ''valid'' signals are coupled.
+ * @param useSyncReadMem True uses SyncReadMem instead of Mem as an internal memory element.
+ * @param hasFlush True if generated queue requires a flush feature
+ * @example {{{
+ * val q = Module(new Queue(UInt(), 16))
+ * q.io.enq <> producer.io.out
+ * consumer.io.in <> q.io.deq
+ * }}}
+ */
+class Queue_SRAM[T <: Data](
+                        val gen:            T,
+                        val entries:        Int,
+                        val pipe:           Boolean = false,
+                        val flow:           Boolean = false,
+                        val useSyncReadMem: Boolean = false,
+                        val hasFlush:       Boolean = false
+                      )(
+                        implicit compileOptions: chisel3.CompileOptions)
+  extends Module() {
+  require(entries > -1, "Queue must have non-negative number of entries")
+  require(entries != 0, "Use companion object Queue.apply for zero entries")
+  val genType = if (compileOptions.declaredTypeMustBeUnbound) {
+    requireIsChiselType(gen)
+    gen
+  } else {
+    if (DataMirror.internal.isSynthesizable(gen)) {
+      chiselTypeOf(gen)
+    } else {
+      gen
+    }
+  }
+
+  val io = IO(new QueueIO(genType, entries, hasFlush))
+  // val ram = if (useSyncReadMem) SyncReadMem(entries, genType, SyncReadMem.WriteFirst) else Mem(entries, genType)
+  val ram = SyncReadMem(entries, genType)
+  val enq_ptr = Counter(entries)
+  val deq_ptr = Counter(entries)
+  val maybe_full = RegInit(false.B)
+  val ptr_match = enq_ptr.value === deq_ptr.value
+  val empty = ptr_match && !maybe_full
+  val full = ptr_match && maybe_full
+  val do_enq = WireDefault(io.enq.fire)
+  val do_deq = WireDefault(io.deq.fire)
+  val flush = io.flush.getOrElse(false.B)
+
+  // when flush is high, empty the queue
+  // Semantically, any enqueues happen before the flush.
+  when(do_enq) {
+    ram(enq_ptr.value) := io.enq.bits
+    enq_ptr.inc()
+  }
+  when(do_deq) {
+    deq_ptr.inc()
+  }
+  when(do_enq =/= do_deq) {
+    maybe_full := do_enq
+  }
+  when(flush) {
+    enq_ptr.reset()
+    deq_ptr.reset()
+    maybe_full := false.B
+  }
+
+  io.deq.valid := !empty
+  io.enq.ready := !full
+
+  if (useSyncReadMem) {
+    val deq_ptr_next = Mux(deq_ptr.value === (entries.U - 1.U), 0.U, deq_ptr.value + 1.U)
+    val r_addr = WireDefault(Mux(do_deq, deq_ptr_next, deq_ptr.value))
+    // for dual port SRAM: avoid read/write the same entry at once
+    val not_ren = do_enq && (r_addr === enq_ptr.value)
+    val not_ren_r = RegNext(not_ren, false.B)
+    val enq_data_r = RegEnable(io.enq.bits, not_ren)
+    val r_data = WireInit(0.U.asTypeOf(genType))
+    r_data := ram.read(r_addr, !not_ren)
+
+    io.deq.bits := Mux(not_ren_r, enq_data_r, r_data)
+  } else {
+    io.deq.bits := ram(deq_ptr.value)
+  }
+
+  if (flow) {
+    when(io.enq.valid) { io.deq.valid := true.B }
+    when(empty) {
+      io.deq.bits := io.enq.bits
+      do_deq := false.B
+      when(io.deq.ready) { do_enq := false.B }
+    }
+  }
+
+  if (pipe) {
+    when(io.deq.ready) { io.enq.ready := true.B }
+  }
+
+  val ptr_diff = enq_ptr.value - deq_ptr.value
+
+  if (isPow2(entries)) {
+    io.count := Mux(maybe_full && ptr_match, entries.U, 0.U) | ptr_diff
+  } else {
+    io.count := Mux(
+      ptr_match,
+      Mux(maybe_full, entries.asUInt, 0.U),
+      Mux(deq_ptr.value > enq_ptr.value, entries.asUInt + ptr_diff, ptr_diff)
+    )
+  }
+}
+
+/** Factory for a generic hardware queue. */
+object Queue_SRAM {
+
+  /** Create a [[Queue]] and supply a [[DecoupledIO]] containing the product.
+   *
+   * @param enq input (enqueue) interface to the queue, also determines type of queue elements.
+   * @param entries depth (number of elements) of the queue
+   * @param pipe True if a single entry queue can run at full throughput (like a pipeline). The `ready` signals are
+   *             combinationally coupled.
+   * @param flow True if the inputs can be consumed on the same cycle (the inputs "flow" through the queue immediately).
+   *             The `valid` signals are coupled.
+   * @param useSyncReadMem True uses SyncReadMem instead of Mem as an internal memory element.
+   * @param flush Optional [[Bool]] signal, if defined, the [[Queue.hasFlush]] will be true, and connect correspond
+   *              signal to [[Queue]] instance.
+   * @return output (dequeue) interface from the queue.
+   *
+   * @example {{{
+   *   consumer.io.in <> Queue(producer.io.out, 16)
+   * }}}
+   */
+  @nowarn("cat=deprecation&msg=TransitName")
+  def apply[T <: Data](
+                        enq:            ReadyValidIO[T],
+                        entries:        Int = 2,
+                        pipe:           Boolean = false,
+                        flow:           Boolean = false,
+                        useSyncReadMem: Boolean = false,
+                        flush:          Option[Bool] = None
+                      ): DecoupledIO[T] = {
+    if (entries == 0) {
+      val deq = Wire(new DecoupledIO(chiselTypeOf(enq.bits)))
+      deq.valid := enq.valid
+      deq.bits := enq.bits
+      enq.ready := deq.ready
+      deq
+    } else {
+      val q = Module(new Queue_SRAM(chiselTypeOf(enq.bits), entries, pipe, flow, useSyncReadMem, flush.isDefined))
+      q.io.flush.zip(flush).foreach(f => f._1 := f._2)
+      q.io.enq.valid := enq.valid // not using <> so that override is allowed
+      q.io.enq.bits := enq.bits
+      enq.ready := q.io.enq.ready
+      q.io.deq
+    }
+  }
+
+  /** Create a queue and supply a [[IrrevocableIO]] containing the product.
+   * Casting from [[DecoupledIO]] is safe here because we know the [[Queue]] has
+   * Irrevocable semantics.
+   * we didn't want to change the return type of apply() for backwards compatibility reasons.
+   *
+   * @param enq [[DecoupledIO]] signal to enqueue.
+   * @param entries The max number of entries in the queue
+   * @param pipe True if a single entry queue can run at full throughput (like a pipeline). The ''ready'' signals are
+   * combinationally coupled.
+   * @param flow True if the inputs can be consumed on the same cycle (the inputs "flow" through the queue immediately).
+   * The ''valid'' signals are coupled.
+   * @param useSyncReadMem True uses SyncReadMem instead of Mem as an internal memory element.
+   * @param flush Optional [[Bool]] signal, if defined, the [[Queue.hasFlush]] will be true, and connect correspond
+   *              signal to [[Queue]] instance.
+   * @return a [[DecoupledIO]] signal which should connect to the dequeue signal.
+   *
+   * @example {{{
+   *   consumer.io.in <> Queue(producer.io.out, 16)
+   * }}}
+   */
+  def irrevocable[T <: Data](
+                              enq:            ReadyValidIO[T],
+                              entries:        Int = 2,
+                              pipe:           Boolean = false,
+                              flow:           Boolean = false,
+                              useSyncReadMem: Boolean = false,
+                              flush:          Option[Bool] = None
+                            ): IrrevocableIO[T] = {
+    val deq = apply(enq, entries, pipe, flow, useSyncReadMem, flush)
+    require(entries > 0, "Zero-entry queues don't guarantee Irrevocability")
+    val irr = Wire(new IrrevocableIO(chiselTypeOf(deq.bits)))
+    irr.bits := deq.bits
+    irr.valid := deq.valid
+    deq.ready := irr.ready
+    irr
+  }
+}

--- a/src/main/scala/coupledL2/utils/Queue_SRAM.scala
+++ b/src/main/scala/coupledL2/utils/Queue_SRAM.scala
@@ -1,6 +1,18 @@
-// SPDX-License-Identifier: Apache-2.0
-
-/** Wrappers for ready-valid (Decoupled) interfaces and associated circuit generators using them.
+/** *************************************************************************************
+ * Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+ * Copyright (c) 2020-2021 Peng Cheng Laboratory
+ *
+ * XiangShan is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ * http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ * *************************************************************************************
  */
 
 package coupledL2.utils


### PR DESCRIPTION
Queue in `TXDAT/GrantBuffer/Source` are replaced with Queue_SRAM

Since they are large (16×512+), it is area-consuming to build with Reg