### PR TITLE
cmo: remove `RVA23` prefix

### DIFF
--- a/src/main/scala/coupledL2/BaseSlice.scala
+++ b/src/main/scala/coupledL2/BaseSlice.scala
@@ -35,8 +35,8 @@ abstract class BaseSliceIO[T_OUT <: BaseOuterBundle](implicit p: Parameters) ext
   // val msStatus = topDownOpt.map(_ => Vec(mshrsAll, ValidIO(new MSHRStatus)))
   val dirResult = topDownOpt.map(_ => ValidIO(new DirResult))
   val latePF = topDownOpt.map(_ => Output(Bool()))
-  val cmoReq = Flipped(DecoupledIO(new RVA23CMOReq()))
-  val cmoResp = DecoupledIO(new RVA23CMOResp())
+  val cmoReq = Flipped(DecoupledIO(new CMOReq()))
+  val cmoResp = DecoupledIO(new CMOResp())
 }
 
 abstract class BaseSlice[T_OUT <: BaseOuterBundle](implicit p: Parameters) extends L2Module {

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -323,12 +323,12 @@ class L2ToL1Hint(implicit p: Parameters) extends Bundle {
 }
 
 // custom l2 - l1 CMO inst req
-class RVA23CMOReq(implicit p: Parameters) extends Bundle {
+class CMOReq(implicit p: Parameters) extends Bundle {
   val opcode = UInt(3.W)   // 0-cbo.clean, 1-cbo.flush, 2-cbo.inval, 3-cbo.zero
   val address = UInt(64.W)
 }
 // custom l2 - l1 CMO inst resp(ack)
-class RVA23CMOResp(implicit p: Parameters) extends Bundle {
+class CMOResp(implicit p: Parameters) extends Bundle {
   val address = UInt(64.W)
 }
 

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -77,7 +77,7 @@ trait HasCoupledL2Parameters {
   def hasTPPrefetcher = prefetchers.exists(_.isInstanceOf[TPParameters])
   def hasPrefetchBit = prefetchers.exists(_.hasPrefetchBit) // !! TODO.test this
   def hasPrefetchSrc = prefetchers.exists(_.hasPrefetchSrc)
-  def hasRVA23CMO = cacheParams.hasRVA23CMO
+  def hasCMO = cacheParams.hasCMO
   def topDownOpt = if(cacheParams.elaboratedTopDown) Some(true) else None
 
   def enableHintGuidedGrant = true
@@ -224,8 +224,8 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
     if(hasReceiver) Some(BundleBridgeSink(Some(() => new PrefetchRecv))) else None
   val tpmeta_source_node = if(hasTPPrefetcher) Some(BundleBridgeSource(() => DecoupledIO(new TPmetaReq))) else None
   val tpmeta_sink_node = if(hasTPPrefetcher) Some(BundleBridgeSink(Some(() => ValidIO(new TPmetaResp)))) else None
-  val cmo_sink_node = if(hasRVA23CMO) Some(BundleBridgeSink(Some(() => DecoupledIO(new RVA23CMOReq)))) else None
-  val cmo_source_node = if(hasRVA23CMO) Some(BundleBridgeSource(Some(() => DecoupledIO(new RVA23CMOResp)))) else None
+  val cmo_sink_node = if(hasCMO) Some(BundleBridgeSink(Some(() => DecoupledIO(new CMOReq)))) else None
+  val cmo_source_node = if(hasCMO) Some(BundleBridgeSource(Some(() => DecoupledIO(new CMOResp)))) else None
   
   val managerPortParams = (m: TLSlavePortParameters) => TLSlavePortParameters.v1(
     m.managers.map { m =>

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -105,7 +105,7 @@ case class L2Param(
   // env
   FPGAPlatform: Boolean = false,
   // CMO
-  hasRVA23CMO: Boolean = false,
+  hasCMO: Boolean = false,
 
   // Network layer SAM
   sam: Seq[(AddressSet, Int)] = Seq(AddressSet.everything -> 0)

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -41,7 +41,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
     val sinkB    = Flipped(DecoupledIO(new TaskBundle))
     val sinkC    = Flipped(DecoupledIO(new TaskBundle))
     val mshrTask = Flipped(DecoupledIO(new TaskBundle))
-    val cmoTask  = if (hasRVA23CMO) Some(Flipped(DecoupledIO(new TaskBundle))) else None
+    val cmoTask  = if (hasCMO) Some(Flipped(DecoupledIO(new TaskBundle))) else None
 
     /* read/write directory */
     val dirRead_s1 = DecoupledIO(new DirRead())  // To directory, read meta/tag

--- a/src/main/scala/coupledL2/SinkCMO.scala
+++ b/src/main/scala/coupledL2/SinkCMO.scala
@@ -28,7 +28,7 @@ import utility.MemReqSource
 // SinkCMO receives upwards CMO_Inst Req, and send it to RequestArb directly
 class SinkCMO(implicit p: Parameters) extends L2Module {
   val io = IO(new Bundle() {
-    val cmoReq = Flipped(DecoupledIO(new RVA23CMOReq()))
+    val cmoReq = Flipped(DecoupledIO(new CMOReq()))
     val task = DecoupledIO(new TaskBundle)
   })
 

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -39,7 +39,7 @@ class MSHRTasks(implicit p: Parameters) extends TL2CHIL2Bundle {
   val source_b = DecoupledIO(new SourceBReq)
   val mainpipe = DecoupledIO(new TaskBundle) // To Mainpipe (SourceC or SourceD)
   // val prefetchTrain = prefetchOpt.map(_ => DecoupledIO(new PrefetchTrain)) // To prefetcher
-  val cmoResp = DecoupledIO(new RVA23CMOResp()) // To L1 CMO_channel
+  val cmoResp = DecoupledIO(new CMOResp()) // To L1 CMO_channel
 }
 
 class MSHRResps(implicit p: Parameters) extends TL2CHIL2Bundle {

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -62,7 +62,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     val toTXREQ = DecoupledIO(new CHIREQ())
     val toTXRSP = DecoupledIO(new CHIRSP()) // TODO: unify with main pipe, which should be TaskBundle
     val toSourceB = DecoupledIO(new TLBundleB(edgeIn.bundle))
-    val cmoResp = DecoupledIO(new RVA23CMOResp())
+    val cmoResp = DecoupledIO(new CMOResp())
 
     /* to block sourceB from sending same-addr probe until GrantAck received */
     val grantStatus = Input(Vec(grantBufInflightSize, new GrantStatus()))

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -97,8 +97,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   reqArb.io.sinkB <> rxsnp.io.task
   reqArb.io.sinkC <> sinkC.io.task
   reqArb.io.mshrTask <> mshrCtl.io.mshrTask
-  reqArb.io.cmoTask.foreach(_ := sinkCMO.io.task)
-  if (!hasRVA23CMO) { sinkCMO.io.task.ready := false.B }
+  reqArb.io.cmoTask.foreach(_ <> sinkCMO.io.task)
+  if (!hasCMO) { sinkCMO.io.task.ready := false.B }
   reqArb.io.fromMSHRCtl := mshrCtl.io.toReqArb
   reqArb.io.fromMainPipe := mainPipe.io.toReqArb
   reqArb.io.fromGrantBuffer := grantBuf.io.toReqArb

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -161,7 +161,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   grantBuf.io.e <> inBuf.e(io.in.e)
   io.cmoReq.ready := false.B
   io.cmoResp.valid := false.B
-  io.cmoResp.bits := 0.U.asTypeOf(new RVA23CMOResp)
+  io.cmoResp.bits := 0.U.asTypeOf(new CMOResp)
 
   /* connect downward channels */
   io.out.a <> outBuf.a(mshrCtl.io.sourceA)


### PR DESCRIPTION
This PR Remove `RVA23` prefix in code, and fix a wire connecting problem when enable CMO