### PR TITLE
LinkLayer: During reset RXLINKACTIVEACK must be deasserted

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
@@ -223,7 +223,7 @@ class CHIAsyncBridgeSink(params: AsyncQueueParams = AsyncQueueParams())(implicit
     //                     output clock      │
     //
     io.deq.txsactive := SynchronizerShiftReg(io.async.txsactive, numSyncReg, Some("sync_txsactive"))
-    io.deq.rx.linkactiveack := SynchronizerShiftReg(io.async.rx.linkactiveack, numSyncReg, Some("sync_rx_linkactiveack"))
+    io.deq.rx.linkactiveack := SynchronizerShiftReg(io.async.rx.linkactiveack, numSyncReg, Some("sync_rx_linkactiveack")) && resetFinish
     io.deq.tx.linkactivereq := SynchronizerShiftReg(io.async.tx.linkactivereq, numSyncReg, Some("sync_tx_linkactivereq")) && resetFinish
     io.deq.syscoreq := SynchronizerShiftReg(io.async.syscoreq, numSyncReg, Some("sync_syscoreq"))
 

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -300,7 +300,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIMsgParamet
 
   io.out.txsactive := true.B
   io.out.tx.linkactivereq := !reset.asBool
-  io.out.rx.linkactiveack := RegNext(io.out.rx.linkactivereq) || !rxDeact
+  io.out.rx.linkactiveack := (RegNext(io.out.rx.linkactivereq) || !rxDeact) && !reset.asBool
 
   io.out.syscoreq := true.B
 


### PR DESCRIPTION
During reset the following interface signals must be deasserted by the component:

* TX***LCRDV
* TX***FLITV
* TXLINKACTIVEREQ and RXLINKACTIVEACK

The earliest point after reset that it is permitted to begin driving these signals HIGH is at a rising CLK edge after RESETn is HIGH.