### PR TITLE
TL2CHICoupledL2: manage PCredits among MMIO and cacheable together

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/Bundle.scala
+++ b/src/main/scala/coupledL2/tl2chi/Bundle.scala
@@ -72,3 +72,11 @@ class MSHRStatus(implicit p: Parameters) extends TL2CHIL2Bundle
   val is_prefetch = Bool()
 
 }
+
+class PCrdQueryBundle(implicit p: Parameters) extends TL2CHIL2Bundle with HasCHIOpcodes {
+  val query = Output(ValidIO(new Bundle() {
+    val pCrdType = UInt(PCRDTYPE_WIDTH.W)
+    val srcID = UInt(SRCID_WIDTH.W)
+  }))
+  val grant = Input(Bool())
+}

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -66,10 +66,6 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val resp = DecoupledIO(new TLBundleD(edge.bundle))
     val chi = new DecoupledNoSnpPortIO
     val id = Input(UInt())
-    // val pCrdQuery = Output(ValidIO(new Bundle() {
-    //   val pCrdType = UInt(PCRDTYPE_WIDTH.W)
-    // }))
-    // val pCrdGrant = Input(Bool())
     val pCrd = new PCrdQueryBundle
     val waitOnReadReceipt = Option.when(needRR)(Output(Bool()))
   })
@@ -263,30 +259,6 @@ class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
   /**
     * Protocol Retry
     */
-  // val pCrdValids = RegInit(VecInit(Seq.fill(mmioBridgeSize)(false.B)))
-  // val pCrdTypes = Reg(Vec(mmioBridgeSize, UInt(PCRDTYPE_WIDTH.W)))
-  // val pCrdInsertOH = PriorityEncoderOH(pCrdValids.map(!_))
-  // val isPCrdGrant = io.rx.rsp.bits.opcode === PCrdGrant
-  // val pCrdMatch = Wire(Vec(mmioBridgeSize, Vec(mmioBridgeSize, Bool())))
-  // val pCrdMatchEntryVec = pCrdMatch.map(_.asUInt.orR)
-  // val pCrdMatchEntryOH = PriorityEncoderOH(pCrdMatchEntryVec)
-  // val pCrdFreeOH = ParallelPriorityMux(
-  //   pCrdMatchEntryVec,
-  //   pCrdMatch.map(x => VecInit(PriorityEncoderOH(x)))
-  // )
-
-  // when (io.rx.rsp.valid && isPCrdGrant) {
-  //   pCrdValids.zip(pCrdInsertOH).foreach { case (v, insert) => 
-  //     when (insert) { v := true.B }
-  //     assert(!(v && insert), "P-Credit overflow")
-  //   }
-  //   pCrdTypes.zip(pCrdInsertOH).foreach { case (t, insert) =>
-  //     when (insert) { t := io.rx.rsp.bits.pCrdType }
-  //   }
-  // }
-  // pCrdFreeOH.zip(pCrdValids).foreach { case (free, v) =>
-  //   when (free) { v := false.B }
-  // }
   val isPCrdGrant = io_pCrd.map(_.grant).reduce(_ || _)
   io_pCrd.zip(entries).foreach(x => x._1 <> x._2.io.pCrd)
 
@@ -301,12 +273,6 @@ class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
     entry.io.chi.rx.rsp.bits := io.rx.rsp.bits
 
     entry.io.id := i.U
-
-    // pCrdMatch(i) := VecInit(pCrdValids.zip(pCrdTypes).map { case (v, t) => 
-    //   entry.io.pCrdQuery.valid && v &&
-    //   entry.io.pCrdQuery.bits.pCrdType === t
-    // })
-    // entry.io.pCrdGrant := pCrdMatchEntryOH(i)
   }
 
   val txreqArb = Module(new Arbiter(chiselTypeOf(io.tx.req.bits), mmioBridgeSize))

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -241,6 +241,7 @@ class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
   val (bus, edge) = outer.mmioNode.in.head
 
   val io = IO(new DecoupledNoSnpPortIO)
+  val debug_pcrdGrantFire = IO(Output(Bool()))
 
   val entries = Seq.fill(mmioBridgeSize) { Module(new MMIOBridgeEntry(edge)) }
   val readys = VecInit(entries.map(_.io.req.ready))
@@ -323,6 +324,8 @@ class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
   io.rx.rsp.ready := Cat(entries.zipWithIndex.map { case (entry, i) =>
     entry.io.chi.rx.rsp.ready && io.rx.rsp.bits.txnID === i.U
   }).orR || isPCrdGrant
+
+  debug_pcrdGrantFire := io.rx.rsp.valid && isPCrdGrant
 
   dontTouch(io)
   dontTouch(bus)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1017,7 +1017,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.channel := req.channel
 
   assert(!(c_resp.valid && !io.status.bits.w_c_resp))
-  assert(!(rxrsp.valid && !io.status.bits.w_d_resp))
+  assert(!(rxrsp.valid && rxrsp.bits.chiOpcode.get =/= PCrdGrant && !io.status.bits.w_d_resp))
 
   /* ======== Handling Nested C ======== */
   // for A miss, only when replResp do we finally choose a way, allowing nested C

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -43,11 +43,9 @@ class MSHRTasks(implicit p: Parameters) extends TL2CHIL2Bundle {
 }
 
 class MSHRResps(implicit p: Parameters) extends TL2CHIL2Bundle {
-  val sinkC = Flipped(ValidIO(new RespInfoBundle))  
-  val rxrsp = Flipped(ValidIO(new RespInfoBundle))  
-  val rxdat = Flipped(ValidIO(new RespInfoBundle))  
-//  val rxrsp = new RespBundle()  
-//  val rxdat = new RespBundle()  
+  val sinkC = Flipped(ValidIO(new RespInfoBundle))
+  val rxrsp = Flipped(ValidIO(new RespInfoBundle))
+  val rxdat = Flipped(ValidIO(new RespInfoBundle))
 }
 
 class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
@@ -62,8 +60,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     val nestedwbData = Output(Bool())
     val aMergeTask = Flipped(ValidIO(new TaskBundle))
     val replResp = Flipped(ValidIO(new ReplacerResult))
-    // val pCrdPri = Input(Bool())
-    // val waitPCrdInfo = Output(new PCrdInfo)
     val pCrd = new PCrdQueryBundle
   })
 
@@ -113,10 +109,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       Cat( true.B, TRUNK) -> UD,
       Cat( true.B, TIP)   -> UD
     ))
-  //for PCrdGrant info. search
-  // io.waitPCrdInfo.valid := gotRetryAck && !gotPCrdGrant
-  // io.waitPCrdInfo.srcID.get := srcid
-  // io.waitPCrdInfo.pCrdType.get := pcrdtype
+
   io.pCrd.query.valid := gotRetryAck && !gotPCrdGrant
   io.pCrd.query.bits.pCrdType := pcrdtype
   io.pCrd.query.bits.srcID := srcid

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -62,8 +62,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     val nestedwbData = Output(Bool())
     val aMergeTask = Flipped(ValidIO(new TaskBundle))
     val replResp = Flipped(ValidIO(new ReplacerResult))
-    val pCrdPri = Input(Bool())
-    val waitPCrdInfo = Output(new PCrdInfo)
+    // val pCrdPri = Input(Bool())
+    // val waitPCrdInfo = Output(new PCrdInfo)
+    val pCrd = new PCrdQueryBundle
   })
 
   require (chiOpt.isDefined)
@@ -113,9 +114,12 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       Cat( true.B, TIP)   -> UD
     ))
   //for PCrdGrant info. search
-  io.waitPCrdInfo.valid := gotRetryAck && !gotPCrdGrant
-  io.waitPCrdInfo.srcID.get := srcid
-  io.waitPCrdInfo.pCrdType.get := pcrdtype
+  // io.waitPCrdInfo.valid := gotRetryAck && !gotPCrdGrant
+  // io.waitPCrdInfo.srcID.get := srcid
+  // io.waitPCrdInfo.pCrdType.get := pcrdtype
+  io.pCrd.query.valid := gotRetryAck && !gotPCrdGrant
+  io.pCrd.query.bits.pCrdType := pcrdtype
+  io.pCrd.query.bits.srcID := srcid
 
   /* Allocation */
   when (io.alloc.valid) {
@@ -912,7 +916,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   }
 
   // when rxrsp is PCrdGrant
-  when (io.pCrdPri) {
+  when (io.pCrd.grant) {
     state.s_reissue.get := false.B
     gotPCrdGrant := true.B
   }

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -93,7 +93,10 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     /* to Slice Top for pCrd info.*/
     val waitPCrdInfo  = Output(Vec(mshrsAll, new PCrdInfo))
     val matchPCrdInfo = Input(UInt(mshrsAll.W))
-})
+
+    /* debug */
+    val debug_pcrdGrantFire = Output(Vec(mshrsAll, Bool()))
+  })
 
   /*MSHR allocation pointer gen -> to Mainpipe*/
   class MSHRSelector(implicit p: Parameters) extends L2Module {
@@ -284,6 +287,8 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
       case (in, s) => in := s.io.status
     }
   )
+
+  io.debug_pcrdGrantFire := pCrdPri
   /* Performance counters */
 /*  XSPerfAccumulate("capacity_conflict_to_sinkA", a_mshrFull)
   XSPerfAccumulate("capacity_conflict_to_sinkB", mshrFull)

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -28,12 +28,12 @@ import coupledL2.prefetch.PrefetchTrain
 import coupledL2._
 
 // PCrd info for MSHR Retry 
-class PCrdInfo(implicit p: Parameters) extends TL2CHIL2Bundle
-{
-  val valid = Bool()
-  val srcID = chiOpt.map(_ => UInt(SRCID_WIDTH.W))
-  val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
-}
+// class PCrdInfo(implicit p: Parameters) extends TL2CHIL2Bundle
+// {
+//   val valid = Bool()
+//   val srcID = chiOpt.map(_ => UInt(SRCID_WIDTH.W))
+//   val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
+// }
 
 class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val io = IO(new Bundle() {
@@ -91,11 +91,9 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     val msStatus = topDownOpt.map(_ => Vec(mshrsAll, ValidIO(new MSHRStatus)))
 
     /* to Slice Top for pCrd info.*/
-    val waitPCrdInfo  = Output(Vec(mshrsAll, new PCrdInfo))
-    val matchPCrdInfo = Input(UInt(mshrsAll.W))
-
-    /* debug */
-    val debug_pcrdGrantFire = Output(Vec(mshrsAll, Bool()))
+    // val waitPCrdInfo  = Output(Vec(mshrsAll, new PCrdInfo))
+    // val matchPCrdInfo = Input(UInt(mshrsAll.W))
+    val pCrd = Vec(mshrsAll, new PCrdQueryBundle)
   })
 
   /*MSHR allocation pointer gen -> to Mainpipe*/
@@ -122,91 +120,91 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
   mshrSelector.io.idle := mshrs.map(m => !m.io.status.valid)
   io.toMainPipe.mshr_alloc_ptr := OHToUInt(selectedMSHROH)
 
-  /*
-   when PCrdGrant, give credit to one entry that:
-   1. got RetryAck and not Reissued
-   2. match srcID and PCrdType
-   3. use Round-Robin arbiter if multi-entry match
-   */
-  val isPCrdGrant = io.resps.rxrsp.valid && (io.resps.rxrsp.respInfo.chiOpcode.get === PCrdGrant)
-  val isPCrdGrantReg = RegNext(isPCrdGrant)
-  val waitPCrdInfo  = Wire(Vec(mshrsAll, new PCrdInfo))
-  val timeOutPri = VecInit(Seq.fill(16)(false.B))
-  val timeOutSel = WireInit(false.B)
-  val pCrdPri = VecInit(Seq.fill(16)(false.B))
-  val pArb = Module(new RRArbiterInit(UInt(), mshrsAll))
+//   /*
+//    when PCrdGrant, give credit to one entry that:
+//    1. got RetryAck and not Reissued
+//    2. match srcID and PCrdType
+//    3. use Round-Robin arbiter if multi-entry match
+//    */
+//   val isPCrdGrant = io.resps.rxrsp.valid && (io.resps.rxrsp.respInfo.chiOpcode.get === PCrdGrant)
+//   val isPCrdGrantReg = RegNext(isPCrdGrant)
+//   val waitPCrdInfo  = Wire(Vec(mshrsAll, new PCrdInfo))
+//   val timeOutPri = VecInit(Seq.fill(16)(false.B))
+//   val timeOutSel = WireInit(false.B)
+//   val pCrdPri = VecInit(Seq.fill(16)(false.B))
+//   val pArb = Module(new RRArbiterInit(UInt(), mshrsAll))
 
-  val matchPCrdGrantPre = VecInit(pCrdPri.zip(io.matchPCrdInfo.asBools.map(_ & io.resps.rxrsp.valid)).map{
-    case(a,b) => !a & b
-  })
-  val  matchPCrdGrant = RegNext(matchPCrdGrantPre)
+//   val matchPCrdGrantPre = VecInit(pCrdPri.zip(io.matchPCrdInfo.asBools.map(_ & io.resps.rxrsp.valid)).map{
+//     case(a,b) => !a & b
+//   })
+//   val  matchPCrdGrant = RegNext(matchPCrdGrantPre)
    
-  pArb.io.in.zipWithIndex.foreach {
-    case (in, i) =>
-      in.valid := matchPCrdGrant(i)
-      in.bits := 0.U
-  }
-  pArb.io.out.ready := true.B
+//   pArb.io.in.zipWithIndex.foreach {
+//     case (in, i) =>
+//       in.valid := matchPCrdGrant(i)
+//       in.bits := 0.U
+//   }
+//   pArb.io.out.ready := true.B
 
-  val pCrdOH = VecInit(UIntToOH(pArb.io.chosen).asBools)
-  val pCrdFixPri = VecInit(pCrdOH zip matchPCrdGrant map {case(a,b) => a && b})
+//   val pCrdOH = VecInit(UIntToOH(pArb.io.chosen).asBools)
+//   val pCrdFixPri = VecInit(pCrdOH zip matchPCrdGrant map {case(a,b) => a && b})
 
-  // timeout protect
-  val counter = RegInit(VecInit(Seq.fill(mshrsAll)(0.U((log2Ceil(mshrsAll)+1).W))))
+//   // timeout protect
+//   val counter = RegInit(VecInit(Seq.fill(mshrsAll)(0.U((log2Ceil(mshrsAll)+1).W))))
 
-  for(i <- 0 until 16) {
-    when(matchPCrdGrant(i)) {
-      when(!timeOutSel && pCrdFixPri(i) || timeOutPri(i)) {
-        counter(i):=0.U
-      }.otherwise {
-        counter(i):= counter(i) + 1.U
-      }
-    }
-  }
-  val timeOutOH = PriorityEncoderOH(counter.map(_>=12.U) zip matchPCrdGrant map {case(a,b) => a&&b})
-  timeOutPri := VecInit(timeOutOH)
+//   for(i <- 0 until 16) {
+//     when(matchPCrdGrant(i)) {
+//       when(!timeOutSel && pCrdFixPri(i) || timeOutPri(i)) {
+//         counter(i):=0.U
+//       }.otherwise {
+//         counter(i):= counter(i) + 1.U
+//       }
+//     }
+//   }
+//   val timeOutOH = PriorityEncoderOH(counter.map(_>=12.U) zip matchPCrdGrant map {case(a,b) => a&&b})
+//   timeOutPri := VecInit(timeOutOH)
 
-  timeOutSel := timeOutPri.reduce(_|_)
-  pCrdPri := Mux(timeOutSel, timeOutPri, pCrdFixPri)
+//   timeOutSel := timeOutPri.reduce(_|_)
+//   pCrdPri := Mux(timeOutSel, timeOutPri, pCrdFixPri)
 
-  dontTouch (timeOutPri)
-  dontTouch (timeOutSel)
-  dontTouch (pCrdOH)
-  dontTouch (pCrdFixPri)
-  dontTouch (pCrdPri)
+//   dontTouch (timeOutPri)
+//   dontTouch (timeOutSel)
+//   dontTouch (pCrdOH)
+//   dontTouch (pCrdFixPri)
+//   dontTouch (pCrdPri)
 
-  /* when PCrdGrant come before RetryAck, 16 entry CAM used to:
-   1. save {srcID, PCrdType} 
-   2. Broadcast to each MSHR for seaching when RetryAck   
-   */
-//  val pCamValids = RegInit(VecInit(Seq.fill(mshrsAll){ false.B }))
-  val pCam  = RegInit(VecInit(Seq.fill(mshrsAll)(0.U.asTypeOf(new PCrdInfo))))
-  val pCamPri = Wire(UInt(5.W))
-  val pCamValids = Cat(pCam.map(_.valid))
-  val enqIdx = PriorityEncoder(~pCamValids.asUInt)
+//   /* when PCrdGrant come before RetryAck, 16 entry CAM used to:
+//    1. save {srcID, PCrdType} 
+//    2. Broadcast to each MSHR for seaching when RetryAck   
+//    */
+// //  val pCamValids = RegInit(VecInit(Seq.fill(mshrsAll){ false.B }))
+//   val pCam  = RegInit(VecInit(Seq.fill(mshrsAll)(0.U.asTypeOf(new PCrdInfo))))
+//   val pCamPri = Wire(UInt(5.W))
+//   val pCamValids = Cat(pCam.map(_.valid))
+//   val enqIdx = PriorityEncoder(~pCamValids.asUInt)
 
-//  when (isPCrdGrant && !pCrdIsWait.orR){
-  when (isPCrdGrant){
-    pCam(enqIdx).valid := true.B
-    pCam(enqIdx).srcID.get := io.resps.rxrsp.respInfo.srcID.get
-    pCam(enqIdx).pCrdType.get := io.resps.rxrsp.respInfo.pCrdType.get
-  }
+// //  when (isPCrdGrant && !pCrdIsWait.orR){
+//   when (isPCrdGrant){
+//     pCam(enqIdx).valid := true.B
+//     pCam(enqIdx).srcID.get := io.resps.rxrsp.respInfo.srcID.get
+//     pCam(enqIdx).pCrdType.get := io.resps.rxrsp.respInfo.pCrdType.get
+//   }
 
-  pCamPri := 16.U  //out of range of mshrAll 
+//   pCamPri := 16.U  //out of range of mshrAll 
 
-  //each entry zip pCam
-  for (i <- 0 until mshrsAll) { //entry
-    when (waitPCrdInfo(i).valid) {
-      for (j <- 0 until mshrsAll) { //pCam
-        when (pCam(j).valid &&
-              waitPCrdInfo(i).srcID.get === pCam(j).srcID.get &&
-              waitPCrdInfo(i).srcID.get === pCam(j).pCrdType.get) {
-          pCam(j).valid := false.B
-          pCamPri := i.U
-        }
-      }
-    }
-  }
+//   //each entry zip pCam
+//   for (i <- 0 until mshrsAll) { //entry
+//     when (waitPCrdInfo(i).valid) {
+//       for (j <- 0 until mshrsAll) { //pCam
+//         when (pCam(j).valid &&
+//               waitPCrdInfo(i).srcID.get === pCam(j).srcID.get &&
+//               waitPCrdInfo(i).srcID.get === pCam(j).pCrdType.get) {
+//           pCam(j).valid := false.B
+//           pCamPri := i.U
+//         }
+//       }
+//     }
+//   }
 
   /* SinkC(release) search MSHR with PA */
   val resp_sinkC_match_vec = mshrs.map { mshr =>
@@ -229,7 +227,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
       m.io.resps.rxdat.valid := m.io.status.valid && io.resps.rxdat.valid && io.resps.rxdat.mshrId === i.U
       m.io.resps.rxdat.bits := io.resps.rxdat.respInfo
 
-      m.io.resps.rxrsp.valid := m.io.status.valid && io.resps.rxrsp.valid && !isPCrdGrant && (io.resps.rxrsp.mshrId === i.U)
+      m.io.resps.rxrsp.valid := m.io.status.valid && io.resps.rxrsp.valid/* && !isPCrdGrant*/ && (io.resps.rxrsp.mshrId === i.U)
       m.io.resps.rxrsp.bits := io.resps.rxrsp.respInfo
 
       m.io.replResp.valid := io.replResp.valid && io.replResp.bits.mshrId === i.U
@@ -240,11 +238,13 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
       m.io.aMergeTask.valid := io.aMergeTask.valid && io.aMergeTask.bits.id === i.U
       m.io.aMergeTask.bits := io.aMergeTask.bits.task
 
-      waitPCrdInfo(i) := m.io.waitPCrdInfo
-      m.io.pCrdPri := isPCrdGrantReg && pCrdPri(i)
+      io.pCrd(i) <> m.io.pCrd
+
+      // waitPCrdInfo(i) := m.io.waitPCrdInfo
+      // m.io.pCrdPri := isPCrdGrantReg && pCrdPri(i)
   }
-  /* mshrc -> L2Top to wait pCrd */
-  io.waitPCrdInfo <> waitPCrdInfo
+  // /* mshrc -> L2Top to wait pCrd */
+  // io.waitPCrdInfo <> waitPCrdInfo
 
   /* Reserve 1 entry for SinkB */
   io.toReqArb.blockC_s1 := false.B
@@ -288,7 +288,6 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     }
   )
 
-  io.debug_pcrdGrantFire := pCrdPri
   /* Performance counters */
 /*  XSPerfAccumulate("capacity_conflict_to_sinkA", a_mshrFull)
   XSPerfAccumulate("capacity_conflict_to_sinkB", mshrFull)

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -33,10 +33,10 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   val io = IO(new BaseSliceIO[OuterBundle] {
     override val out: OuterBundle = new OuterBundle
   })
-  val io_waitPCrdInfo = IO(Output(Vec(mshrsAll, new PCrdInfo)))
-  val io_matchPCrdInfo = IO(Input(UInt(mshrsAll.W)))
+  // val io_waitPCrdInfo = IO(Output(Vec(mshrsAll, new PCrdInfo)))
+  // val io_matchPCrdInfo = IO(Input(UInt(mshrsAll.W)))
+  val io_pCrd = IO(Vec(mshrsAll, new PCrdQueryBundle))
   val io_msStatus = topDownOpt.map(_ => IO(Vec(mshrsAll, ValidIO(new MSHRStatus))))
-  val debug_pcrdGrantFire = IO(Output(Vec(mshrsAll, Bool())))
 
   /* Upwards TileLink-related modules */
   val sinkA = Module(new SinkA)
@@ -179,9 +179,9 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
     p.recv_addr := 0.U.asTypeOf(p.recv_addr)
   }
 
-  /* to Slice Top for pCrd info.*/
-  io_waitPCrdInfo <> mshrCtl.io.waitPCrdInfo
-  io_matchPCrdInfo <> mshrCtl.io.matchPCrdInfo
+  // /* to Slice Top for pCrd info.*/
+  // io_waitPCrdInfo <> mshrCtl.io.waitPCrdInfo
+  // io_matchPCrdInfo <> mshrCtl.io.matchPCrdInfo
   /* IO Connection */
   io.l1Hint <> mainPipe.io.l1Hint
   topDownOpt.foreach (
@@ -212,5 +212,5 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   rxdat.io.out <> io.out.rx.dat
   rxrsp.io.out <> io.out.rx.rsp
 
-  debug_pcrdGrantFire := mshrCtl.io.debug_pcrdGrantFire
+  io_pCrd <> mshrCtl.io.pCrd
 }

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -33,8 +33,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   val io = IO(new BaseSliceIO[OuterBundle] {
     override val out: OuterBundle = new OuterBundle
   })
-  // val io_waitPCrdInfo = IO(Output(Vec(mshrsAll, new PCrdInfo)))
-  // val io_matchPCrdInfo = IO(Input(UInt(mshrsAll.W)))
   val io_pCrd = IO(Vec(mshrsAll, new PCrdQueryBundle))
   val io_msStatus = topDownOpt.map(_ => IO(Vec(mshrsAll, ValidIO(new MSHRStatus))))
 
@@ -179,9 +177,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
     p.recv_addr := 0.U.asTypeOf(p.recv_addr)
   }
 
-  // /* to Slice Top for pCrd info.*/
-  // io_waitPCrdInfo <> mshrCtl.io.waitPCrdInfo
-  // io_matchPCrdInfo <> mshrCtl.io.matchPCrdInfo
   /* IO Connection */
   io.l1Hint <> mainPipe.io.l1Hint
   topDownOpt.foreach (

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -36,6 +36,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   val io_waitPCrdInfo = IO(Output(Vec(mshrsAll, new PCrdInfo)))
   val io_matchPCrdInfo = IO(Input(UInt(mshrsAll.W)))
   val io_msStatus = topDownOpt.map(_ => IO(Vec(mshrsAll, ValidIO(new MSHRStatus))))
+  val debug_pcrdGrantFire = IO(Output(Vec(mshrsAll, Bool())))
 
   /* Upwards TileLink-related modules */
   val sinkA = Module(new SinkA)
@@ -211,4 +212,5 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   rxdat.io.out <> io.out.rx.dat
   rxrsp.io.out <> io.out.rx.rsp
 
+  debug_pcrdGrantFire := mshrCtl.io.debug_pcrdGrantFire
 }

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -212,21 +212,22 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
           pCrdMatch.map(x => VecInit(PriorityEncoderOH(x)))
         )
 
-        when (isPCrdGrant) {
-          pCrdValids.zipWithIndex.foreach { case (v, i) =>
-            val t = pCrdTypes(i)
-            val srcID = pCrdSrcIDs(i)
-            val insert = pCrdInsertOH(i)
-            val free = pCrdFreeOH(i)
+        pCrdValids.zipWithIndex.foreach { case (v, i) =>
+          val t = pCrdTypes(i)
+          val srcID = pCrdSrcIDs(i)
+          val insert = pCrdInsertOH(i)
+          val free = pCrdFreeOH(i)
+          when (isPCrdGrant) {
             when (insert) {
               v := true.B
               t := rxrsp.bits.pCrdType
               srcID := rxrsp.bits.srcID
             }
-            when (free) { v := false.B }
             assert(!(v && insert), "P-Credit overflow")
-            assert(!free || v, "invalid entry should not be free")
           }
+
+          when (free) { v := false.B }
+          assert(!free || v, "invalid entry should not be free")
         }
 
         for (i <- 0 until entries) {

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -155,42 +155,6 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         val rxrsp = Wire(DecoupledIO(new CHIRSP))
         val rxrspIsMMIO = rxrsp.bits.txnID.head(1).asBool
         val isPCrdGrant = rxrsp.valid && rxrsp.bits.opcode === PCrdGrant
-        // val pArb = Module(new RRArbiterInit(UInt(), banks))
-        // val pMatch = VecInit(Seq.fill(banks)(Module(new PCrdGrantMatcher(mshrsAll)).io))
-        // val pCrdSliceID = Wire(UInt(log2Ceil(banks).W))
-        // /*
-        // when PCrdGrant, give credit to one Slice that:
-        // 1. got RetryAck and not Reissued
-        // 2. match srcID and PCrdType
-        // 3. use Round-Robin arbiter if multi-Slice match
-        // */
-        // val matchPCrdGrant = Wire(Vec(banks, UInt(mshrsAll.W)))
-        // val validCounts = Wire(Vec(banks, UInt(log2Ceil(mshrsAll+1).W)))
-        // slices.zipWithIndex.foreach { case (s, i) =>
-        //   pMatch(i).io_waitPCrdInfo := s.io_waitPCrdInfo
-        //   pMatch(i).rxrsp.bits.srcID := rxrsp.bits.srcID
-        //   pMatch(i).rxrsp.bits.pCrdType := rxrsp.bits.pCrdType
-        //   pMatch(i).isPCrdGrant := isPCrdGrant
-
-        //   matchPCrdGrant(i) := pMatch(i).matchPCrdGrant
-        //   s.io_matchPCrdInfo := matchPCrdGrant(i)
-        //   validCounts(i) := PopCount(s.io_waitPCrdInfo.map(_.valid))
-        // }
-
-        // val pCrdIsWait = VecInit(matchPCrdGrant.map(_.asUInt.orR)).asUInt
-        // val pCrdSliceIDOH = UIntToOH(pCrdSliceID)
-        // val onlyValidraw = Cat(validCounts.map(count => count === 1.U)).asUInt
-        // val onlyValid = Reverse(onlyValidraw)
-        // val pCrdSliceHit = pCrdSliceIDOH & pCrdIsWait & onlyValid
-        // val pCrdCancel = RegNext(pCrdSliceHit) & onlyValid
-
-        // pArb.io.in.zipWithIndex.foreach {
-        //   case (in, i) =>
-        //     in.valid := pCrdIsWait(i) && !pCrdCancel(i)
-        //     in.bits := 0.U
-        // }
-        // pArb.io.out.ready := true.B
-        // pCrdSliceID := pArb.io.chosen
 
         // PCredit arbitration
         val (mmioQuerys, mmioGrants) = mmio.io_pCrd.map { case x => (x.query, x.grant) }.unzip

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -208,6 +208,14 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
           Cat(slices.zipWithIndex.map { case (s, i) => s.io.out.rx.rsp.ready && rxrspSliceID === i.U }).orR
         )
 
+        val pcrdGrantFireVec = Cat(
+          RegNext(mmio.debug_pcrdGrantFire),
+          Cat(slices.map(_.debug_pcrdGrantFire.asUInt))
+        )
+        assert(!RegNext(isPCrdGrant) || PopCount(pcrdGrantFireVec) === 1.U,
+          "Only one mshr may receive PCrdGrant one a time")
+
+
         // RXDAT
         val rxdat = Wire(DecoupledIO(new CHIDAT))
         val rxdatIsMMIO = rxdat.bits.txnID.head(1).asBool

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -154,46 +154,92 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         // RXRSP
         val rxrsp = Wire(DecoupledIO(new CHIRSP))
         val rxrspIsMMIO = rxrsp.bits.txnID.head(1).asBool
-        val isPCrdGrant = rxrsp.valid && (rxrsp.bits.opcode === PCrdGrant)
-        val pArb = Module(new RRArbiterInit(UInt(), banks))
-        val pMatch = VecInit(Seq.fill(banks)(Module(new PCrdGrantMatcher(mshrsAll)).io))
-        val pCrdSliceID = Wire(UInt(log2Ceil(banks).W))
-        /*
-        when PCrdGrant, give credit to one Slice that:
-        1. got RetryAck and not Reissued
-        2. match srcID and PCrdType
-        3. use Round-Robin arbiter if multi-Slice match
-        */
-        val matchPCrdGrant = Wire(Vec(banks, UInt(mshrsAll.W)))
-        val validCounts = Wire(Vec(banks, UInt(log2Ceil(mshrsAll+1).W)))
-        slices.zipWithIndex.foreach { case (s, i) =>
-          pMatch(i).io_waitPCrdInfo := s.io_waitPCrdInfo
-          pMatch(i).rxrsp.bits.srcID := rxrsp.bits.srcID
-          pMatch(i).rxrsp.bits.pCrdType := rxrsp.bits.pCrdType
-          pMatch(i).isPCrdGrant := isPCrdGrant
+        val isPCrdGrant = rxrsp.valid && rxrsp.bits.opcode === PCrdGrant
+        // val pArb = Module(new RRArbiterInit(UInt(), banks))
+        // val pMatch = VecInit(Seq.fill(banks)(Module(new PCrdGrantMatcher(mshrsAll)).io))
+        // val pCrdSliceID = Wire(UInt(log2Ceil(banks).W))
+        // /*
+        // when PCrdGrant, give credit to one Slice that:
+        // 1. got RetryAck and not Reissued
+        // 2. match srcID and PCrdType
+        // 3. use Round-Robin arbiter if multi-Slice match
+        // */
+        // val matchPCrdGrant = Wire(Vec(banks, UInt(mshrsAll.W)))
+        // val validCounts = Wire(Vec(banks, UInt(log2Ceil(mshrsAll+1).W)))
+        // slices.zipWithIndex.foreach { case (s, i) =>
+        //   pMatch(i).io_waitPCrdInfo := s.io_waitPCrdInfo
+        //   pMatch(i).rxrsp.bits.srcID := rxrsp.bits.srcID
+        //   pMatch(i).rxrsp.bits.pCrdType := rxrsp.bits.pCrdType
+        //   pMatch(i).isPCrdGrant := isPCrdGrant
 
-          matchPCrdGrant(i) := pMatch(i).matchPCrdGrant
-          s.io_matchPCrdInfo := matchPCrdGrant(i)
-          validCounts(i) := PopCount(s.io_waitPCrdInfo.map(_.valid))
+        //   matchPCrdGrant(i) := pMatch(i).matchPCrdGrant
+        //   s.io_matchPCrdInfo := matchPCrdGrant(i)
+        //   validCounts(i) := PopCount(s.io_waitPCrdInfo.map(_.valid))
+        // }
+
+        // val pCrdIsWait = VecInit(matchPCrdGrant.map(_.asUInt.orR)).asUInt
+        // val pCrdSliceIDOH = UIntToOH(pCrdSliceID)
+        // val onlyValidraw = Cat(validCounts.map(count => count === 1.U)).asUInt
+        // val onlyValid = Reverse(onlyValidraw)
+        // val pCrdSliceHit = pCrdSliceIDOH & pCrdIsWait & onlyValid
+        // val pCrdCancel = RegNext(pCrdSliceHit) & onlyValid
+
+        // pArb.io.in.zipWithIndex.foreach {
+        //   case (in, i) =>
+        //     in.valid := pCrdIsWait(i) && !pCrdCancel(i)
+        //     in.bits := 0.U
+        // }
+        // pArb.io.out.ready := true.B
+        // pCrdSliceID := pArb.io.chosen
+
+        // PCredit arbitration
+        val (mmioQuerys, mmioGrants) = mmio.io_pCrd.map { case x => (x.query, x.grant) }.unzip
+        val (slicesQuerys, slicesGrants) = slices.map { case s =>
+          (s.io_pCrd.map(_.query), s.io_pCrd.map(_.grant))
+        }.unzip
+        val querys = mmioQuerys ++ slicesQuerys.flatten
+        val grants = mmioGrants ++ slicesGrants.flatten
+        val entries = querys.length
+        val pCrdValids = RegInit(VecInit(Seq.fill(entries)(false.B)))
+        val pCrdTypes = Reg(Vec(entries, UInt(PCRDTYPE_WIDTH.W)))
+        val pCrdSrcIDs = Reg(Vec(entries, UInt(SRCID_WIDTH.W)))
+        val pCrdInsertOH = PriorityEncoderOH(pCrdValids.map(!_))
+        val pCrdMatch = Wire(Vec(entries, Vec(entries, Bool())))
+        val pCrdMatchEntryVec = pCrdMatch.map(_.asUInt.orR)
+        val pCrdMatchEntryOH = PriorityEncoderOH(pCrdMatchEntryVec)
+        val pCrdFreeOH = ParallelPriorityMux(
+          pCrdMatchEntryVec,
+          pCrdMatch.map(x => VecInit(PriorityEncoderOH(x)))
+        )
+
+        when (isPCrdGrant) {
+          pCrdValids.zipWithIndex.foreach { case (v, i) =>
+            val t = pCrdTypes(i)
+            val srcID = pCrdSrcIDs(i)
+            val insert = pCrdInsertOH(i)
+            val free = pCrdFreeOH(i)
+            when (insert) {
+              v := true.B
+              t := rxrsp.bits.pCrdType
+              srcID := rxrsp.bits.srcID
+            }
+            when (free) { v := false.B }
+            assert(!(v && insert), "P-Credit overflow")
+            assert(!free || v, "invalid entry should not be free")
+          }
         }
 
-        val pCrdIsWait = VecInit(matchPCrdGrant.map(_.asUInt.orR)).asUInt
-        val pCrdSliceIDOH = UIntToOH(pCrdSliceID)
-        val onlyValidraw = Cat(validCounts.map(count => count === 1.U)).asUInt
-        val onlyValid = Reverse(onlyValidraw)
-        val pCrdSliceHit = pCrdSliceIDOH & pCrdIsWait & onlyValid
-        val pCrdCancel = RegNext(pCrdSliceHit) & onlyValid
-
-        pArb.io.in.zipWithIndex.foreach {
-          case (in, i) =>
-            in.valid := pCrdIsWait(i) && !pCrdCancel(i)
-            in.bits := 0.U
+        for (i <- 0 until entries) {
+          pCrdMatch(i) := VecInit(pCrdValids.zip(pCrdTypes).zip(pCrdSrcIDs).map { case ((v, t), s) =>
+            querys(i).valid && v &&
+            querys(i).bits.pCrdType === t &&
+            querys(i).bits.srcID === s
+          })
+          grants(i) := pCrdMatchEntryOH(i)
         }
-        pArb.io.out.ready := true.B
-        pCrdSliceID := pArb.io.chosen
 
 
-        val rxrspSliceID = Mux(isPCrdGrant, pCrdSliceID, getSliceID(rxrsp.bits.txnID))
+        val rxrspSliceID = getSliceID(rxrsp.bits.txnID)
         slices.zipWithIndex.foreach { case (s, i) =>
           s.io.out.rx.rsp.valid := rxrsp.valid && rxrspSliceID === i.U && !rxrspIsMMIO
           s.io.out.rx.rsp.bits := rxrsp.bits
@@ -207,14 +253,6 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
           mmio.io.rx.rsp.ready,
           Cat(slices.zipWithIndex.map { case (s, i) => s.io.out.rx.rsp.ready && rxrspSliceID === i.U }).orR
         )
-
-        val pcrdGrantFireVec = Cat(
-          RegNext(mmio.debug_pcrdGrantFire),
-          Cat(slices.map(_.debug_pcrdGrantFire.asUInt))
-        )
-        assert(!RegNext(isPCrdGrant) || PopCount(pcrdGrantFireVec) === 1.U,
-          "Only one mshr may receive PCrdGrant one a time")
-
 
         // RXDAT
         val rxdat = Wire(DecoupledIO(new CHIDAT))


### PR DESCRIPTION
This pull request fixes the following possible PCredit related bugs:

1. RetryAck is typically sent by the Completer before PCrdGrant. However, it is permitted to send RetryAck after PCrdGrant. When the latter situation happens, the transaction with credit must only be sent by the Requester after both the RetryAck response and an appropriate PCrdGrant response are received. Before this fix CoupledL2 is unable to handle the latter situation and might drop a PCredit or handle out a PCredit to more than one MSHR.
2. The TxnID field of the PCrdGrant response is not used and must be set to zero. However, before this fix, CoupledL2 hands out all the RXRSP responses, including PCrdGrant, according to the most significant bit in TxnID, which makes MMIOBridge unable to receive PCrdGrant.

This pull request fixes the above bugs by managing all the PCredit among MMIO and cacheable MSHRs together. All the PCrdGrant responses that CoupledL2 receives will be cached in `PCrdTypes` and `PCrdSrcIDs` register files. When an MSHR receives a RetryAck, it will look for a PCrdGrant with appropriate PCrdType and SrcID.