### PR TITLE
timing(MMIOBridge, TL2CHICoupledL2): optimize PCredit timing

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -214,7 +214,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
 
         for (i <- 0 until entries) {
           pCrdMatch(i) := VecInit(pCrdValids.zip(pCrdTypes).zip(pCrdSrcIDs).map { case ((v, t), s) =>
-            querys(i).valid && v &&
+            querys(i).valid && !grants(i) && v &&
             querys(i).bits.pCrdType === t &&
             querys(i).bits.srcID === s
           })

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -218,7 +218,9 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
           })
           grants(i) := RegNext(pCrdMatchEntryOH(i))
         }
-
+        val grantCnt = RegInit(0.U(64.W))
+        grantCnt := grantCnt + PopCount(grants)
+        dontTouch(grantCnt)
 
         val rxrspSliceID = getSliceID(rxrsp.bits.txnID)
         slices.zipWithIndex.foreach { case (s, i) =>


### PR DESCRIPTION
This commit optimizes timing by:
* adding a pipeline stage to update `PCrdValids`
* adding a pipeline stage to arbitrate PCredits to all the slices
* always being ready for RXRSP responses