### PR TITLE
feat(Common, MSHR): set TXREQ with the highest priority

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -138,6 +138,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   def toCHIREQBundle(): CHIREQ = {
     val req = WireInit(0.U.asTypeOf(new CHIREQ()))
+    req.qos := Fill(QOS_WIDTH, 1.U(1.W)) // TODO
     req.tgtID := tgtID.getOrElse(0.U)
     req.srcID := srcID.getOrElse(0.U)
     req.txnID := txnID.getOrElse(0.U)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -291,7 +291,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val a_task = {
     val oa = io.tasks.txreq.bits
     oa := 0.U.asTypeOf(io.tasks.txreq.bits.cloneType)
-//    oa.qos := Mux(!state.s_reissue, 3.U, 0.U) //TODO increase qos when retry
+    oa.qos := Fill(QOS_WIDTH, 1.U(1.W)) // TODO
     oa.tgtID := Mux(!state.s_reissue.getOrElse(false.B), srcid, 0.U)
     oa.srcID := 0.U
     oa.txnID := io.id


### PR DESCRIPTION
The QoS *Priority Value* for packets is dependent on the source type and the class of traffic with ascending values of QoS indicating a higher priority level. In the previous design QoS is always set to zero, resulting in a rather low use ratio of CMN.

This commit sets all the TXREQ requests with the highest priority to fully utilize the resources in HN-Fs.