### PR TITLE
timing, area(NetworkLayer, TL2CHICoupledL2): PCredit management

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -159,7 +159,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         // PCredit queue
         class EmptyBundle extends Bundle
 
-        val homeNodeIDs = p(HomeNodeInfoKey).id
+        val homeNodeIDs = p.lift(HomeNodeInfoKey).getOrElse(new HomeNodeInfo).id
         val homeNodeCount = homeNodeIDs.length
 
         val (mmioQuerys, mmioGrants) = mmio.io_pCrd.map { case x => (x.query, x.grant) }.unzip

--- a/src/main/scala/coupledL2/tl2chi/chi/NetworkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/NetworkLayer.scala
@@ -20,6 +20,7 @@ package coupledL2.tl2chi
 import chisel3._
 import chisel3.util._
 import freechips.rocketchip.diplomacy.AddressSet
+import org.chipsalliance.cde.config.Field
 import utility.ParallelPriorityMux
 
 /**
@@ -42,3 +43,15 @@ object SAM {
   def apply(sam: Seq[(AddressSet, Int)]) = new SAM(sam)
   def apply(sam: (AddressSet, Int)) = new SAM(Seq(sam))
 }
+
+/**
+  * Home Node IDs
+  * 
+  * It's required for CoupledL2 (as RNs) to hold the information of HNs on the network
+  * to implement P-Credit management efficiently.
+  */
+case class HomeNodeInfo (
+  id: Seq[Int] = Seq(0)
+)
+
+case object HomeNodeInfoKey extends Field[HomeNodeInfo]

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -81,6 +81,7 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
       here(L2ParamKey).enableRollingDB && !here(L2ParamKey).FPGAPlatform,
       i
     )
+    case HomeNodeInfoKey => HomeNodeInfo(id = Seq(0))
   }))))
 
   val bankBinders = (0 until numCores).map(_ => BankBinder(banks, 64))
@@ -149,7 +150,7 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
       dontTouch(l2.module.io)
 
       l2.module.io.hartId := i.U
-      l2.module.io_nodeID := i.U(NODEID_WIDTH.W)
+      l2.module.io_nodeID := (i + 1).U
       l2.module.io.debugTopDown := DontCare
       l2.module.io.l2_tlb_req <> DontCare
     }
@@ -176,8 +177,8 @@ object TestTopCHIHelper {
         elaboratedTopDown   = false,
         FPGAPlatform        = FPGAPlatform,
 
-        // SAM for tester ICN: Home Node ID = 33
-        sam                 = Seq(AddressSet.everything -> 33)
+        // using external RN-F SAM
+        sam                 = Seq(AddressSet.everything -> 0)
       )
     })
 
@@ -208,8 +209,8 @@ object TestTop_CHI_DualCore_2UL extends App {
 
   TestTopCHIHelper.gen(p => new TestTop_CHIL2(
     numCores = 2,
-    numULAgents = 0,
-    banks = 1)(p)
+    numULAgents = 2,
+    banks = 4)(p)
   )(args)
 }
 
@@ -227,7 +228,7 @@ object TestTop_CHI_DualCore_2UL_Eb extends App {
 
   TestTopCHIHelper.gen(p => new TestTop_CHIL2(
     numCores = 2,
-    numULAgents = 0,
+    numULAgents = 2,
     banks = 1,
     issue = "E.b")(p)
   )(args)


### PR DESCRIPTION
This commit introduces a new PCredit management mechanism by:
* implement PCredit pool with simple Queue
* awareness of Home Nodes inside CoupledL2 RN
* seperate PCredit Queue for every Home Node under small-scale
  multi-core scenarios
* PCredit dispatch with fast RR arbiter

**NOTICE**: The monolithic approach of PCredit Queue was to be implemented
        in the future to better support many cores scenarios with the
        area-aware Home-Node-count threshold.