### PR TITLE
RequestBuffer: remove duplicate prefetch with MainPipe

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -36,6 +36,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /* status from arbiter at stage1  */
     val taskInfo_s1 = Flipped(ValidIO(new TaskBundle()))
 
+    val taskInfo_s3 = Output(new TaskBundle())
+
     /* handle set conflict in req arb */
     val fromReqArb = Input(new Bundle() {
       val status_s1 = new PipeEntranceStatus
@@ -135,6 +137,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   when (task_s2.valid) {
     task_s3.bits := task_s2.bits
   }
+
+  io.taskInfo_s3 := task_s3
 
   /* ======== Enchantment ======== */
   val dirResult_s3    = io.dirResp_s3

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -35,6 +35,8 @@ class MainPipe(implicit p: Parameters) extends L2Module {
     /* receive task from arbiter at stage 2 */
     val taskFromArb_s2 = Flipped(ValidIO(new TaskBundle()))
 
+    val taskInfo_s3 = ValidIO(new TaskBundle())
+
     /* handle set conflict in req arb */
     val fromReqArb = Input(new Bundle() {
       val status_s1 = new PipeEntranceStatus
@@ -128,6 +130,8 @@ class MainPipe(implicit p: Parameters) extends L2Module {
   when(task_s2.valid) {
     task_s3.bits := task_s2.bits
   }
+
+  io.taskInfo_s3 := task_s3
 
   /* ======== Enchantment ======== */
   val dirResult_s3    = io.dirResp_s3

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -60,6 +60,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   a_reqBuf.io.mainPipeBlock := mainPipe.io.toReqBuf
   a_reqBuf.io.s1Entrance := reqArb.io.s1Entrance
   a_reqBuf.io.taskFromArb_s2 := reqArb.io.taskToPipe_s2
+  a_reqBuf.io.taskFromMP_s3 := mainPipe.io.taskInfo_s3
 
   sinkB.io.msInfo := mshrCtl.io.msInfo
   sinkC.io.msInfo := mshrCtl.io.msInfo


### PR DESCRIPTION
MainPipe adds an output interface taskInfo_s3 to pass task_s3 information to RequestBuffer. RequestBuffer now can remove more duplicate prefetching by passing in task information from the taskFromArb_s2 and taskFromMP_s3 interfaces. RequestBuffer now ensures that there will be at most one prefetch request for a block from RequestBuffer, RequsetArb, MainPipe, and MSHR.

Had done the SPEC06 30% Coverage.