### PR TITLE
fix(MSHR): CompAck must only be sent after CompData or RespSepData

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -61,7 +61,7 @@ class RXSNP(
   val reqBlockSnp = reqBlockSnpMask.orR
 
   /**
-    * When should an MSHR that is goint to replace cacheline Y block/nest an incoming snoop with address Y?
+    * When should an MSHR that is going to replace cacheline Y block/nest an incoming snoop with address Y?
     * 
     * 1. After MSHR decides which way to replace but before MSHR finished all the rProbes, the incoming snoop of Y
     *    should be **blocked**, because Once the Probe is issued the slave should not issue further Probes on the block
@@ -70,12 +70,13 @@ class RXSNP(
     */
   val replaceBlockSnpMask = VecInit(io.msInfo.map(s =>
     s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit && isValid(s.bits.metaState) &&
-    s.bits.w_replResp && (!s.bits.w_rprobeacklast || s.bits.w_releaseack) && !s.bits.willFree
+    s.bits.w_replResp && (!s.bits.w_rprobeacklast || s.bits.w_releaseack || !RegNext(s.bits.w_replResp)) &&
+    !s.bits.willFree
   )).asUInt
   val replaceBlockSnp = replaceBlockSnpMask.orR
   val replaceNestSnpMask = VecInit(io.msInfo.map(s =>
       s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit && s.bits.metaState =/= INVALID &&
-      s.bits.w_replResp && s.bits.w_rprobeacklast && !s.bits.w_releaseack
+      RegNext(s.bits.w_replResp) && s.bits.w_rprobeacklast && !s.bits.w_releaseack
     )).asUInt
   val replaceDataMask = VecInit(io.msInfo.map(_.bits.replaceData)).asUInt
 


### PR DESCRIPTION
According to CHI issue E.b spec, the CompAck must only be sent after a CompData or RespSepData is received. In the previous design, if DataSepResp comes before RespSepData, MSHR will send CompAck as long as all the beats of DataSepResp are received which violates the spec.

This commit assigns the status control registers `w_grant`, `w_grantfirst` and `w_grantlast` with new meanings:

* `w_grant`: a CompData or Comp or RespSepData is received
* `w_grantfirst`: a Comp, or the first beat of CompData or DataSepResp is received
* `w_grantlast`: a Comp, or the last beat of CompData or DataSepResp is received

so that CompAck can only be sent when `w_grant` is asserted.