### PR TITLE
feat(TL2CHICoupledL2): monolithic PCredit Queue

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/NetworkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/NetworkLayer.scala
@@ -43,15 +43,3 @@ object SAM {
   def apply(sam: Seq[(AddressSet, Int)]) = new SAM(sam)
   def apply(sam: (AddressSet, Int)) = new SAM(Seq(sam))
 }
-
-/**
-  * Home Node IDs
-  * 
-  * It's required for CoupledL2 (as RNs) to hold the information of HNs on the network
-  * to implement P-Credit management efficiently.
-  */
-case class HomeNodeInfo (
-  id: Seq[Int] = Seq(0)
-)
-
-case object HomeNodeInfoKey extends Field[HomeNodeInfo]

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -81,7 +81,6 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
       here(L2ParamKey).enableRollingDB && !here(L2ParamKey).FPGAPlatform,
       i
     )
-    case HomeNodeInfoKey => HomeNodeInfo(id = Seq(0))
   }))))
 
   val bankBinders = (0 until numCores).map(_ => BankBinder(banks, 64))


### PR DESCRIPTION
This commit unified PCredit management mechanism by:
* re-implement PCredit pool with monolithic single Queue
* store (Home Node) SrcID in queue
* decoupled NoC (Home Node) configuration with CoupledL2