### PR TITLE
fix(DataStorage): fix MCP2 gated clock

### DIFF
--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -63,7 +63,7 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     readMCP2 = true
   ))
 
-  val masked_clock = ClockGate(false.B, io.req.valid, clock)
+  val masked_clock = ClockGate(false.B, io.en, clock)
   array.clock := masked_clock
 
   val arrayIdx = Cat(io.req.bits.way, io.req.bits.set)


### PR DESCRIPTION
Since now io.req.valid lasts two cycles,
it shall no longer be used to generate gated clock,
causing double clk for single req.

Instead, we should use io.en now.