### PR TITLE
fix(MSHR): send CompAck only when the first beat of data is received

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -218,7 +218,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.tasks.txreq.valid := !state.s_acquire && !((req_cmoClean || req_cmoFlush) && (!state.w_releaseack || !state.w_rprobeacklast)) ||
                           !state.s_reissue.getOrElse(false.B) && !state.w_grant && gotRetryAck && gotPCrdGrant ||
                           release_valid2
-  io.tasks.txrsp.valid := !state.s_compack.get && state.w_grant
+  io.tasks.txrsp.valid := !state.s_compack.get && state.w_grantfirst && state.w_grant
   io.tasks.source_b.valid := !state.s_pprobe || !state.s_rprobe
   val mp_release_valid = release_valid1
   val mp_cbwrdata_valid = !state.s_cbwrdata.getOrElse(true.B) && state.w_releaseack


### PR DESCRIPTION
According to CHI issue E.b spec, the CompAck must only be sent after a CompData or RespSepData is received. It is permitted, but not required, to wait for DataSepResp before sending CompAck. Therefore in the previous design, MSHRs send out a CompAck as soon as a CompData or RespSepData is received, ignoring DataSepResp.

However, the relative ordering of transactions issued by an RN, and snoop transactions caused by transactions from different RNs, is controlled by CompAck. As soon as a CompAck is received, an HN-F is allowed to send a subsequent snoop to the same address. When RN gives a CompAck, this RN is indicating that it will accept responsibility to hazard snoops for any transaction that is scheduled after it. In the previous design CoupledL2 is unable to order snoop after RespSepData is received but DataSepResp is not.

Consider the following two solutions:
1. order snoop after RespSepData,
2. send CompAck only when (1) the first beat of CompData is received, or (2) RespSepData and the first beat of DataSepResp is received.

The 1st solution may introduce extra design complexity, thus this commit adopts the 2nd solution to ensure that a snoop transaction that is ordered after the read by HN is guaranteed to be received after data is received.