### PR TITLE
fix(MSHR): update client bits with directory result

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -521,7 +521,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         INVALID,
         Mux(snpToB, BRANCH, meta.state)
       ),
-      clients = Fill(clientBits, !probeGotN && !snpToN),
+      clients = meta.clients & Fill(clientBits, !probeGotN && !snpToN),
       alias = meta.alias, //[Alias] Keep alias bits unchanged
       prefetch = !snpToN && meta_pft,
       accessed = !snpToN && meta.accessed


### PR DESCRIPTION
* 'Get' operations would leave a cache copy with Branch permission in L2 Cache and with no presence of cache line in L1 D-Cache.

* 'SnpRespDataFwded's are permitted to update directory meta for now.

* 'SnpRespDataFwded' with response state of SharedClean does not actually indicate that L1 D-Cache holds the cache line (which might be fetched by non-coherent nodes, e.g. L1 I-Cache, PTW), so on meta update, the client bits of directory meta must be updated with respect to directory read result in addition to the request of invalidating the cache line.