### PR TITLE
fix(LinkLayer): latch `linkactive*` signals before async bridge

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -299,8 +299,11 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   LCredit2Decoupled(io.out.rx.dat, io.in.rx.dat, LinkState(rxState), rxdatDeact, Some("rxdat"))
 
   io.out.txsactive := true.B
-  io.out.tx.linkactivereq := !reset.asBool
-  io.out.rx.linkactiveack := (RegNext(io.out.rx.linkactivereq) || !rxDeact) && !reset.asBool
+  io.out.tx.linkactivereq := RegNext(true.B, init = false.B)
+  io.out.rx.linkactiveack := RegNext(
+    next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
+    init = false.B
+  )
 
   io.out.syscoreq := true.B
 


### PR DESCRIPTION
`txlinkactivereq` and `rxlinkactiveack` should be driven by cpu clock and will cross NoC clock in the asynchronous bridge therefore should not be generated by combination logics. This commit makes sure that such signals are latched before transmitted to the asynchronous bridge.