### PR TITLE
timing(TL2CHICoupledL2): 2-stage pipelined P-Credit grant

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -28,6 +28,7 @@ import org.chipsalliance.cde.config.{Parameters, Field}
 import scala.math.max
 import coupledL2._
 import coupledL2.prefetch._
+import coupledL2.utils._
 
 abstract class TL2CHIL2Bundle(implicit val p: Parameters) extends Bundle
   with HasCoupledL2Parameters
@@ -159,44 +160,80 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         // PCredit queue
         class EmptyBundle extends Bundle
 
+        class PCrdGranted extends Bundle {
+          val pCrdType = UInt(PCRDTYPE_WIDTH.W)
+          val srcID = UInt(SRCID_WIDTH.W)
+        }
+
         val (mmioQuerys, mmioGrants) = mmio.io_pCrd.map { case x => (x.query, x.grant) }.unzip
         val (slicesQuerys, slicesGrants) = slices.map { case s =>
           (s.io_pCrd.map(_.query), s.io_pCrd.map(_.grant))
         }.unzip
-        val mshrPCrdQuerys = mmioQuerys ++ slicesQuerys.flatten
-        val mshrPCrdGrants = mmioGrants ++ slicesGrants.flatten
+        val mshrPCrdQuerySets = Seq(mmioQuerys) ++ slicesQuerys
+        val mshrPCrdGrantSets = Seq(mmioGrants) ++ slicesGrants
+        
+        val mshrEntryCount = (mmioQuerys ++ slicesQuerys.flatten).length
 
-        val mshrEntryCount = mshrPCrdQuerys.length
+        val pCrdQueue = Module(new Queue(new PCrdGranted, entries = mshrEntryCount - 2))
+        val pCrdBuffer = SpillRegister(new PCrdGranted)
 
-        val pCrdQueue = Module(new Queue(new Bundle {
-          val pCrdType = UInt(PCRDTYPE_WIDTH.W)
-          val srcID = UInt(SRCID_WIDTH.W)
-        }, entries = mshrEntryCount))
+        pCrdBuffer.io.in <> pCrdQueue.io.deq
 
         // PCredit hit by MSHRs
-        val mshrPCrdHits = mshrPCrdQuerys.map((_, pCrdQueue.io.deq)).map { case (q, h) => {
-          q.valid && h.valid && q.bits.pCrdType === h.bits.pCrdType && q.bits.srcID === h.bits.srcID
+        val mshrPCrdHitMask = RegInit(false.B)
+        mshrPCrdHitMask := ~mshrPCrdHitMask
+
+        var mshrPCrdHitIndex = 0
+        val mshrPCrdHitSets_s0 = mshrPCrdQuerySets.map(_.map((_, pCrdBuffer.io.out)).map { case (q, h) => {
+          mshrPCrdHitIndex = mshrPCrdHitIndex + 1
+          q.valid && h.valid && q.bits.pCrdType === h.bits.pCrdType && q.bits.srcID === h.bits.srcID && 
+            (mshrPCrdHitMask ^ (mshrPCrdHitIndex & 0x01).B)
+        }})
+
+        // PCredit dispatch arbitration per-set
+        val mshrPCrdArbGrantSets_s0 = mshrPCrdHitSets_s0.map { case set => {
+          Seq.fill(set.length)(Wire(Bool()))
+        }}
+        val mshrPCrdArbInSets_s0 = mshrPCrdHitSets_s0.zip(mshrPCrdArbGrantSets_s0).map { case (hits, grants) => {
+          hits.zip(grants).map { case (hit, grant) => {
+            val arbPort = Wire(Decoupled(new EmptyBundle))
+            arbPort.valid := hit
+            grant := arbPort.ready
+            arbPort
+          }}
+        }}
+        val mshrPCrdArbOutSets_s0 = mshrPCrdHitSets_s0.map { case set => {
+          Wire(Decoupled(new EmptyBundle))
         }}
 
-        // PCredit dispatch arbitration
-        val mshrPCrdArbGrants = Wire(Vec(mshrEntryCount, Bool()))
-        val mshrPCrdArbIn = mshrPCrdHits.zip(mshrPCrdArbGrants).map { case (hit, grant) => {
+        mshrPCrdArbInSets_s0.zip(mshrPCrdArbOutSets_s0).zipWithIndex.foreach { case ((in, out), i) => {
+          fastArb(in, out, Some(s"pcrdgrant_level0_set${i}"))
+        }}
+
+        // PCredit dispatch arbitration for all slices
+        val mshrPCrdArbIn_s0 = mshrPCrdArbOutSets_s0.map { case setArbOut => {
           val arbPort = Wire(Decoupled(new EmptyBundle))
-          arbPort.valid := hit
-          grant := arbPort.ready
+          arbPort.valid := setArbOut.valid
+          setArbOut.ready := arbPort.ready
           arbPort
         }}
-
-        val mshrPCrdArbOut = {
+        val mshrPCrdArbOut_s0 = {
           val arbPort = Wire(Decoupled(new EmptyBundle))
           arbPort.ready := true.B
-          pCrdQueue.io.deq.ready := arbPort.valid
+          pCrdBuffer.io.out.ready := arbPort.valid
           arbPort
         }
 
-        fastArb(mshrPCrdArbIn, mshrPCrdArbOut, Some("pcrdgrant"))
+        fastArb(mshrPCrdArbIn_s0, mshrPCrdArbOut_s0, Some(s"pcrdgrant_level1"))
 
-        mshrPCrdGrants.zip(mshrPCrdArbGrants).foreach { case (grant, arb) => grant := arb }
+        // PCredit grant to slices
+        val mshrPCrdArbGrantSets_s1 = mshrPCrdArbGrantSets_s0.map { case set => {
+          set.map { case grant => RegNext(grant, false.B) }
+        }}
+
+        mshrPCrdGrantSets.zip(mshrPCrdArbGrantSets_s1).map { case (grants, arbOuts) => {
+          grants.zip(arbOuts).map { case (grant, arbOut) => grant := arbOut}
+        }}
 
         // PCredit receive
         val pCrdGrantValid_s1 = RegNext(isPCrdGrant)

--- a/src/main/scala/coupledL2/utils/SpillRegister.scala
+++ b/src/main/scala/coupledL2/utils/SpillRegister.scala
@@ -1,0 +1,111 @@
+package coupledL2.utils
+
+import chisel3._
+import chisel3.util._
+
+
+/*
+* Spill Register for pipelining ready signals.
+*/
+object SpillRegister {
+
+    def apply[T <: Data](gen: T) = {
+        require(!gen.isInstanceOf[ReadyValidIO[?]],
+            "use 'applyReadyValid(...)' instead when passing in ReadyValidIO")
+        Module(new SpillRegister[T, T](gen))
+    }
+
+    def applyReadyValid[D <: Data](gen: ReadyValidIO[D]) = {
+        Module(new SpillRegister[D, ReadyValidIO[D]](gen))
+    }
+
+    def attachReadyValid[D <: ReadyValidIO[D]](in: ReadyValidIO[D], out: ReadyValidIO[D]) = {
+        val uSpillRegister = Module(new SpillRegister(
+            chiselTypeOf(out)
+        ))
+        uSpillRegister.io.in    <> in
+        uSpillRegister.io.out   <> out
+        uSpillRegister
+    }
+
+    def attachIn[T <: ReadyValidIO[Data]](in: T): T = {
+        val uSpillRegister = Module(new SpillRegister(
+            chiselTypeOf(in)
+        ))
+        uSpillRegister.io.in    <> in
+        uSpillRegister.io.out.asInstanceOf[T]
+    }
+
+    def attachOut[T <: ReadyValidIO[Data]](out: T): T = {
+        val uSpillRegister = Module(new SpillRegister(
+            chiselTypeOf(out)
+        ))
+        uSpillRegister.io.out   <> out
+        uSpillRegister.io.in.asInstanceOf[T]
+    }
+}
+
+class SpillRegister[+D <: Data, +T <: Data](gen: T) extends Module {
+
+    /*
+    * Module I/O
+    * 
+    * @io   input       in  : Input Decoupled Channel, ready-valid.
+    * @io   output      out : Output Decoupeld Channel, ready-valid.
+    */
+    val io = IO(new Bundle {
+        // upstream input
+        val in              : ReadyValidIO[D] = {
+            if (gen.isInstanceOf[ReadyValidIO[Data]])
+                Flipped(gen.asInstanceOf[Data]).asInstanceOf[ReadyValidIO[D]]
+            else
+                Flipped(Decoupled(gen)).asInstanceOf[ReadyValidIO[D]]
+        }
+
+        // downstream output
+        val out             : ReadyValidIO[D] = {
+            if (gen.isInstanceOf[ReadyValidIO[Data]])
+                Flipped(Flipped(gen.asInstanceOf[ReadyValidIO[D]]))
+            else
+                Flipped(Flipped(Decoupled(gen).asInstanceOf[ReadyValidIO[D]]))
+        }
+    })
+
+    
+    //
+    protected def extractDataType: Data   = chiselTypeOf(io.out.bits)
+
+    
+    // Spill Registers
+    protected val reg1stValid   = RegInit(init = false.B)
+    protected val reg1stData    = Reg(extractDataType)
+
+    protected val reg2ndValid   = RegInit(init = false.B)
+    protected val reg2ndData    = Reg(extractDataType)
+
+    when (io.out.ready) {
+
+        when (!reg2ndValid) {
+            reg1stValid := false.B
+        }
+
+        reg2ndValid := false.B
+    }
+
+    when (io.in.fire) {
+        reg1stValid := true.B
+        reg1stData  := io.in.bits
+
+        when (!io.out.ready) {
+            reg2ndValid := reg1stValid
+            reg2ndData  := reg1stData
+        }
+    }
+
+    
+    // output logic
+    io.in.ready     := !reg2ndValid
+
+    io.out.valid    := reg1stValid | reg2ndValid
+    io.out.bits     := Mux(reg2ndValid, reg2ndData, reg1stData)
+}


### PR DESCRIPTION
* Time division multiplexing of P-Credit grant for individual MSHR entries (e.g. permitted grant on cycle 0: MSHR[0, 2, 4 ...], and on cycle 1: MSHR[1, 3, 5, ...]).

* 2-stage 2-level grant arbitration with slice-based grouping.

* Spill Register (skid buffer) attached to P-Credit Queue reading.