### PR TITLE
fix(TXDAT, TXRSP): tightened back-pressure of MSHR tasks

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -69,8 +69,11 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val inflightCnt = PopCount(Cat(pipeStatus_s3_s5.map(s => s.valid && s.bits.toTXDAT && (s.bits.fromB || s.bits.mshrTask)))) +
     PopCount(Cat(pipeStatus_s2.map(s => s.valid && Mux(s.bits.mshrTask, s.bits.toTXDAT, s.bits.fromB)))) +
     queueCnt
+
+  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXDAT")
+
   val noSpaceForSinkBReq = inflightCnt >= mshrsAll.U
-  val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-1).U
+  val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-2).U
 
   io.toReqArb.blockSinkBReqEntrance := noSpaceForSinkBReq
   io.toReqArb.blockMSHRReqEntrance := noSpaceForMSHRReq

--- a/src/main/scala/coupledL2/tl2chi/TXREQ.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXREQ.scala
@@ -61,6 +61,9 @@ class TXREQ(implicit p: Parameters) extends TL2CHIL2Module {
 //    pipeStatus_s1.valid.asUInt +
     1.U - s2ReturnCredit.asUInt + //Fix Timing: always take credit and s2 return if not take 
     queueCnt
+
+  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXREQ")
+
   val noSpace = inflightCnt >= mshrsAll.U
 
   io.toReqArb.blockMSHRReqEntrance := noSpace

--- a/src/main/scala/coupledL2/tl2chi/TXRSP.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXRSP.scala
@@ -59,8 +59,11 @@ class TXRSP(implicit p: Parameters) extends TL2CHIL2Module {
   val inflightCnt = PopCount(Cat(pipeStatus_s3_s5.map(s => s.valid && s.bits.toTXRSP && (s.bits.fromB || s.bits.mshrTask)))) +
     PopCount(Cat(pipeStatus_s2.map(s => s.valid && Mux(s.bits.mshrTask, s.bits.toTXRSP, s.bits.fromB)))) +
     queueCnt
+
+  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXRSP")
+
   val noSpaceForSinkBReq = inflightCnt >= mshrsAll.U
-  val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-1).U
+  val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-2).U
 
   io.toReqArb.blockSinkBReqEntrance := noSpaceForSinkBReq
   io.toReqArb.blockMSHRReqEntrance := noSpaceForMSHRReq


### PR DESCRIPTION
* For DCT, it was possible for one MSHR to propagate two bundled CHI messages (known for combinations of SnpRespDataFwded with CompData on TXDAT and SnpRespFwded with Comp on TXRSP).

* Assertions for TXDAT, TXREQ and TXRSP of overflowed in-flight tasks.