### PR TITLE
chore(TestTop): graceful configuration through arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test-top-fullsys:
 	$(MAKE) gen-test-top SYSTEM=fullSys
 
 test-top-chi:
-	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS)
 
 test-top-chi-dualcore-0ul:
 	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0

--- a/Makefile
+++ b/Makefile
@@ -28,40 +28,43 @@ SIM_MEM_ARGS = --infer-rw --repl-seq-mem -c:$(TOP):-o:$(TOP).v.conf
 MEM_GEN = ./scripts/vlsi_mem_gen
 MEM_GEN_SEP = ./scripts/gen_sep_mem.sh
 
-test-top:
+gen-test-top:
 	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS)
 	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
 
-test-top-chi:
+gen-test-top-chi:
 	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS) $(CHI_TOP_ARGS)
 	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
 
 test-top-l2:
-	$(MAKE) test-top SYSTEM=L2
+	$(MAKE) gen-test-top SYSTEM=L2
 
 test-top-l2standalone:
-	$(MAKE) test-top SYSTEM=L2_Standalone
+	$(MAKE) gen-test-top SYSTEM=L2_Standalone
 
 test-top-l2l3:
-	$(MAKE) test-top SYSTEM=L2L3
+	$(MAKE) gen-test-top SYSTEM=L2L3
 
 test-top-l2l3l2:
-	$(MAKE) test-top SYSTEM=L2L3L2
+	$(MAKE) gen-test-top SYSTEM=L2L3L2
 
 test-top-fullsys:
-	$(MAKE) test-top SYSTEM=fullSys
+	$(MAKE) gen-test-top SYSTEM=fullSys
+
+test-top-chi:
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
 
 test-top-chi-dualcore-0ul:
-	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
 
 test-top-chi-dualcore-2ul:
-	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=2
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=2
 
 test-top-chi-quadcore-0ul:
-	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=0
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=0
 
 test-top-chi-quadcore-2ul:
-	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=2
+	$(MAKE) gen-test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=2
 
 clean:
 	rm -rf ./build

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
 ISSUE ?= B
-
-TEST_TOP_SUFFIX := UNKNOWN
-ifeq ($(ISSUE), B)
-TEST_TOP_SUFFIX :=
-endif
-ifeq ($(ISSUE), E.b)
-TEST_TOP_SUFFIX := _Eb
-endif
-
-ifeq ($(TEST_TOP_SUFFIX), UNKNOWN)
-$(error "Unknown CHI Issue specified: $(ISSUE)")
-endif
+NUM_CORE ?= 2
+NUM_TL_UL ?= 0
+NUM_SLICE ?= 4
+WITH_CHISELDB ?= 1
+WITH_TLLOG ?= 1
+WITH_CHILOG ?= 1
+FPGA ?= 0
 
 init:
 	git submodule update --init
@@ -19,7 +14,14 @@ init:
 compile:
 	mill -i CoupledL2.compile
 
+PASS_ARGS = ISSUE=$(ISSUE) NUM_CORE=$(NUM_CORE) NUM_TL_UL=$(NUM_TL_UL) NUM_SLICE=$(NUM_SLICE) \
+			WITH_CHISELDB=$(WITH_CHISELDB) WITH_TLLOG=$(WITH_TLLOG) WITH_CHILOG=$(WITH_CHILOG) \
+			FPGA=$(FPGA)
+
 TOP = TestTop
+TOP_ARGS = --issue $(ISSUE) --core $(NUM_CORE) --tl-ul $(NUM_TL_UL) --bank $(NUM_SLICE) \
+		   --chiseldb $(WITH_CHISELDB) --tllog $(WITH_TLLOG) --chilog $(WITH_CHILOG) \
+		   --fpga $(FPGA)
 BUILD_DIR = ./build
 TOP_V = $(BUILD_DIR)/$(TOP).v
 SIM_MEM_ARGS = --infer-rw --repl-seq-mem -c:$(TOP):-o:$(TOP).v.conf
@@ -27,7 +29,7 @@ MEM_GEN = ./scripts/vlsi_mem_gen
 MEM_GEN_SEP = ./scripts/gen_sep_mem.sh
 
 test-top:
-	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS)
+	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS) $(TOP_ARGS)
 	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
 
 test-top-l2:
@@ -45,29 +47,20 @@ test-top-l2l3l2:
 test-top-fullsys:
 	$(MAKE) test-top SYSTEM=fullSys
 
+test-top-chi:
+	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS)
+
 test-top-chi-dualcore-0ul:
-	$(MAKE) test-top SYSTEM=CHI_DualCore_0UL$(TEST_TOP_SUFFIX)
+	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
 
 test-top-chi-dualcore-2ul:
-	$(MAKE) test-top SYSTEM=CHI_DualCore_2UL$(TEST_TOP_SUFFIX)
+	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=2 NUM_TL_UL=2
 
 test-top-chi-quadcore-0ul:
-	$(MAKE) test-top SYSTEM=CHI_QuadCore_0UL$(TEST_TOP_SUFFIX)
+	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=4 NUM_TL_UL=0
 
 test-top-chi-quadcore-2ul:
-	$(MAKE) test-top SYSTEM=CHI_QuadCore_2UL$(TEST_TOP_SUFFIX)
-
-test-top-chi-octacore-0ul:
-	$(MAKE) test-top SYSTEM=CHI_OctaCore_0UL$(TEST_TOP_SUFFIX)
-
-test-top-chi-octacore-2ul:
-	$(MAKE) test-top SYSTEM=CHI_OctaCore_2UL$(TEST_TOP_SUFFIX)
-
-test-top-chi-hexacore-0ul:
-	$(MAKE) test-top SYSTEM=CHI_HexaCore_0UL$(TEST_TOP_SUFFIX)
-
-test-top-chi-hexacore-2ul:
-	$(MAKE) test-top SYSTEM=CHI_HexaCore_2UL$(TEST_TOP_SUFFIX)
+	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=4 NUM_TL_UL=2
 
 clean:
 	rm -rf ./build

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ init:
 compile:
 	mill -i CoupledL2.compile
 
-PASS_ARGS = ISSUE=$(ISSUE) NUM_CORE=$(NUM_CORE) NUM_TL_UL=$(NUM_TL_UL) NUM_SLICE=$(NUM_SLICE) \
-			WITH_CHISELDB=$(WITH_CHISELDB) WITH_TLLOG=$(WITH_TLLOG) WITH_CHILOG=$(WITH_CHILOG) \
-			FPGA=$(FPGA)
+CHI_PASS_ARGS = ISSUE=$(ISSUE) NUM_CORE=$(NUM_CORE) NUM_TL_UL=$(NUM_TL_UL) NUM_SLICE=$(NUM_SLICE) \
+			    WITH_CHISELDB=$(WITH_CHISELDB) WITH_TLLOG=$(WITH_TLLOG) WITH_CHILOG=$(WITH_CHILOG) \
+			    FPGA=$(FPGA)
 
 TOP = TestTop
-TOP_ARGS = --issue $(ISSUE) --core $(NUM_CORE) --tl-ul $(NUM_TL_UL) --bank $(NUM_SLICE) \
-		   --chiseldb $(WITH_CHISELDB) --tllog $(WITH_TLLOG) --chilog $(WITH_CHILOG) \
-		   --fpga $(FPGA)
+CHI_TOP_ARGS = --issue $(ISSUE) --core $(NUM_CORE) --tl-ul $(NUM_TL_UL) --bank $(NUM_SLICE) \
+		   	   --chiseldb $(WITH_CHISELDB) --tllog $(WITH_TLLOG) --chilog $(WITH_CHILOG) \
+		       --fpga $(FPGA)
 BUILD_DIR = ./build
 TOP_V = $(BUILD_DIR)/$(TOP).v
 SIM_MEM_ARGS = --infer-rw --repl-seq-mem -c:$(TOP):-o:$(TOP).v.conf
@@ -29,7 +29,11 @@ MEM_GEN = ./scripts/vlsi_mem_gen
 MEM_GEN_SEP = ./scripts/gen_sep_mem.sh
 
 test-top:
-	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS) $(TOP_ARGS)
+	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS)
+	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
+
+test-top-chi:
+	mill -i CoupledL2.test.runMain coupledL2.$(TOP)_$(SYSTEM) -td $(BUILD_DIR) $(SIM_MEM_ARGS) $(CHI_TOP_ARGS)
 	$(MEM_GEN_SEP) "$(MEM_GEN)" "$(TOP_V).conf" "$(BUILD_DIR)"
 
 test-top-l2:
@@ -47,20 +51,17 @@ test-top-l2l3l2:
 test-top-fullsys:
 	$(MAKE) test-top SYSTEM=fullSys
 
-test-top-chi:
-	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS)
-
 test-top-chi-dualcore-0ul:
-	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
+	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=0
 
 test-top-chi-dualcore-2ul:
-	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=2 NUM_TL_UL=2
+	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=2 NUM_TL_UL=2
 
 test-top-chi-quadcore-0ul:
-	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=4 NUM_TL_UL=0
+	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=0
 
 test-top-chi-quadcore-2ul:
-	$(MAKE) test-top SYSTEM=CHIL2 $(PASS_ARGS) NUM_CORE=4 NUM_TL_UL=2
+	$(MAKE) test-top-chi SYSTEM=CHIL2 $(CHI_PASS_ARGS) NUM_CORE=4 NUM_TL_UL=2
 
 clean:
 	rm -rf ./build

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -100,6 +100,8 @@ case class L2Param(
   enableMonitor: Boolean = true,
   // TLLog
   enableTLLog: Boolean = true,
+  // CHILog
+  enableCHILog: Boolean = true,
   // TopDown
   elaboratedTopDown: Boolean = true,
   // env

--- a/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/CHILogger.scala
@@ -24,7 +24,7 @@ import freechips.rocketchip.util._
 import scala.collection.immutable.{ListMap, SeqMap}
 import utility.ChiselDB
 
-class CHILogger(name: String, enable: Boolean, flit_as_is: Boolean = false)
+class CHILogger(name: String, enable: Boolean)
                (implicit val p: Parameters) extends Module with HasCHIOpcodes {
 
   val io = IO(new Bundle() {
@@ -35,7 +35,8 @@ class CHILogger(name: String, enable: Boolean, flit_as_is: Boolean = false)
 
   // packed_flit = true: just dump the whole flit as UInt
   // packed_flit = false: separate every field
-  val packed_flit = flit_as_is
+  val packed_flit = !p(CHIIssue).equals(Issue.B)
+  // *NOTICE: (or TODO) Non-packed flit mode for Issue E.b was currently broken.
 
   // ** !! gather all distinct fields from CHI bundles !! **
   val all_bundles = Seq(new CHIREQ, new CHIRSP, new CHIDAT, new CHISNP)
@@ -181,8 +182,15 @@ class CHILogger(name: String, enable: Boolean, flit_as_is: Boolean = false)
 
 object CHILogger {
   
-  def apply(name: String, enable: Boolean = true)(implicit p: Parameters) = {
-    val logger = Module(new CHILogger(name, enable))
+  def apply(name: String, enable: Boolean)(implicit p: Parameters) = {
+    val logger = Module(new CHILogger(name, enable)(p))
+    logger
+  }
+
+  def apply(name: String, issue: String, enable: Boolean)(implicit p: Parameters) = {
+    val logger = Module(new CHILogger(name, enable)(
+      p.alterPartial { case CHIIssue => issue }
+    ))
     logger
   }
 }

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -11,6 +11,7 @@ import huancun._
 import coupledL2.prefetch._
 import coupledL2.tl2chi._
 import utility._
+import scala.collection.mutable.ArrayBuffer
 
 class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, issue: String = "B")(implicit p: Parameters) extends LazyModule
   with HasCHIMsgParameters {
@@ -145,7 +146,11 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
     }))
 
     l2_nodes.zipWithIndex.foreach { case (l2, i) =>
-      l2.module.io_chi <> io(i).chi
+
+      val chilogger = CHILogger(s"L3_L2[${i}]", issue, !cacheParams.FPGAPlatform && cacheParams.enableCHILog)
+      chilogger.io.up <> l2.module.io_chi
+      chilogger.io.down <> io(i).chi
+
       dontTouch(l2.module.io)
 
       l2.module.io.hartId := i.U
@@ -154,15 +159,16 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
       l2.module.io.l2_tlb_req <> DontCare
     }
   }
-
 }
 
 
 object TestTopCHIHelper {
-  def gen(fTop: Parameters => TestTop_CHIL2)(args: Array[String]) = {
-    val FPGAPlatform    = false
-    val enableChiselDB  = !FPGAPlatform && true
-    
+  def gen(fTop: Parameters => TestTop_CHIL2,
+          onFPGAPlatform: Boolean,
+          enableChiselDB: Boolean,
+          enableTLLog: Boolean,
+          enableCHILog: Boolean)(args: Array[String]) = {
+
     val config = new Config((_, _, _) => {
       case L2ParamKey => L2Param(
         ways                = 4,
@@ -170,11 +176,12 @@ object TestTopCHIHelper {
         clientCaches        = Seq(L1Param(aliasBitsOpt = Some(2), vaddrBitsOpt = Some(36))),
         // echoField        = Seq(DirtyField),
         enablePerf          = false,
-        enableRollingDB     = enableChiselDB && true,
-        enableMonitor       = enableChiselDB && true,
-        enableTLLog         = enableChiselDB && true,
+        enableRollingDB     = !onFPGAPlatform && enableChiselDB,
+        enableMonitor       = !onFPGAPlatform && enableChiselDB,
+        enableTLLog         = !onFPGAPlatform && enableChiselDB && enableTLLog,
+        enableCHILog        = !onFPGAPlatform && enableChiselDB && enableCHILog,
         elaboratedTopDown   = false,
-        FPGAPlatform        = FPGAPlatform,
+        FPGAPlatform        = onFPGAPlatform,
 
         // prefetch
         prefetch            = Seq(BOPParameters()),
@@ -199,158 +206,65 @@ object TestTopCHIHelper {
 }
 
 
-object TestTop_CHI_DualCore_0UL extends App {
+object TestTop_CHIL2 extends App {
 
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 2,
-    numULAgents = 0,
-    banks = 4)(p)
-  )(args)
-}
+  val usage = """
+Usage: TestTop_CHIL2 [<--option> <values>]
 
-object TestTop_CHI_DualCore_2UL extends App {
+      --issue <chi_issue>       specify AMBA CHI Issue of downstream, B by default
+      --core <core_count>       specify core count, 2 by default
+      --tl-ul <tl_ul_count>     specify TileLink-UL upstream count, 0 by default
+      --bank <bank_count>       specify bank (slice) count, 4 by default
+      --fpga <1>                generate for FPGA platform
+      --chiseldb <1>            enable ChisleDB
+      --tllog <1>               enable TLLogger under ChiselDB
+      --chilog <1>              enable CHILogger under ChiselDB
+  """
 
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 2,
-    numULAgents = 2,
-    banks = 4)(p)
-  )(args)
-}
+  if (args.contains("--help"))
+  {
+    println(usage)
+    System.exit(-1)
+  }
 
-object TestTop_CHI_DualCore_0UL_Eb extends App {
+  var varArgs = ArrayBuffer(args:_*)
+  var varArgsDropped = 0
 
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 2,
-    numULAgents = 0,
-    banks = 4,
-    issue = "E.b")(p)
-  )(args)
-}
+  var numCores: Int = 2
+  var numULAgents: Int = 0
+  var numBanks: Int = 4
+  var issue: String = "B"
+  var onFPGAPlatform: Boolean = false
+  var enableChiselDB: Boolean = false
+  var enableTLLog: Boolean = false
+  var enableCHILog: Boolean = false
 
-object TestTop_CHI_DualCore_2UL_Eb extends App {
+  val varArgsToDrop = args.sliding(2, 1).zipWithIndex.collect {
+    case (Array("--issue", value), i) => (issue = value, i)
+    case (Array("--core", value), i) => (numCores = value.toInt, i)
+    case (Array("--tl-ul", value), i) => (numULAgents = value.toInt, i)
+    case (Array("--bank", value), i) => (numBanks = value.toInt, i)
+    case (Array("--fpga", value), i) => (onFPGAPlatform = value.toInt != 0, i)
+    case (Array("--chiseldb", value), i) => (enableChiselDB = value.toInt != 0, i)
+    case (Array("--tllog", value), i) => (enableTLLog = value.toInt != 0, i)
+    case (Array("--chilog", value), i) => (enableCHILog = value.toInt != 0, i)
+  }
 
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 2,
-    numULAgents = 2,
-    banks = 4,
-    issue = "E.b")(p)
-  )(args)
-}
+  varArgsToDrop.map(_._2).foreach(i => {
+    varArgs.remove(i - varArgsDropped, 2)
+    varArgsDropped = varArgsDropped + 2
+  })
+  varArgs.trimToSize
 
-
-
-object TestTop_CHI_QuadCore_0UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 4,
-    numULAgents = 0,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_QuadCore_2UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 4,
-    numULAgents = 2,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_QuadCore_0UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 4,
-    numULAgents = 0,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
-}
-
-object TestTop_CHI_QuadCore_2UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 4,
-    numULAgents = 2,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
-}
-
-
-object TestTop_CHI_OctaCore_0UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 8,
-    numULAgents = 0,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_OctaCore_2UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 8,
-    numULAgents = 2,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_OctaCore_0UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 8,
-    numULAgents = 0,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
-}
-
-object TestTop_CHI_OctaCore_2UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 8,
-    numULAgents = 2,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
-}
-
-
-object TestTop_CHI_HexaCore_0UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 16,
-    numULAgents = 0,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_HexaCore_2UL extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 16,
-    numULAgents = 2,
-    banks = 1)(p)
-  )(args)
-}
-
-object TestTop_CHI_HexaCore_0UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 16,
-    numULAgents = 0,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
-}
-
-object TestTop_CHI_HexaCore_2UL_Eb extends App {
-
-  TestTopCHIHelper.gen(p => new TestTop_CHIL2(
-    numCores = 16,
-    numULAgents = 2,
-    banks = 1,
-    issue = "E.b")(p)
-  )(args)
+  TestTopCHIHelper.gen(
+    p => new TestTop_CHIL2(
+      numCores,
+      numULAgents,
+      numBanks,
+      issue)(p), 
+    onFPGAPlatform,
+    enableChiselDB,
+    enableTLLog,
+    enableCHILog
+  )(varArgs.toArray)
 }

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -147,9 +147,14 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, iss
 
     l2_nodes.zipWithIndex.foreach { case (l2, i) =>
 
-      val chilogger = CHILogger(s"L3_L2[${i}]", issue, !cacheParams.FPGAPlatform && cacheParams.enableCHILog)
-      chilogger.io.up <> l2.module.io_chi
-      chilogger.io.down <> io(i).chi
+      if (!cacheParams.FPGAPlatform && cacheParams.enableCHILog) {
+        val chilogger = CHILogger(s"L3_L2[${i}]", issue, true)
+        chilogger.io.up <> l2.module.io_chi
+        chilogger.io.down <> io(i).chi
+      }
+      else {
+        l2.module.io_chi <> io(i).chi
+      }
 
       dontTouch(l2.module.io)
 


### PR DESCRIPTION
* Use arguments to control generation parameters other than individual App executable classes.

* **CHILogger with flit split is currently broken for Issue E.b**, and to be turned to deprecated, replacing by future support of CHIron CLog.B recording format.