### PR TITLE
feat(MMIOBridge): support Svpbmt on CHI MemAttr

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -48,7 +48,7 @@ case class L1Param
 
 // Pass uncached memory attribute from PBMT to MMIOBridge
 case object MemTypeNC extends ControlKey[Bool]("memType_NC")
-case class MemTypeNCField() extends BundleField[Bool](MemTypeNC, Output(Bool()), _ := true.B)
+case class MemTypeNCField() extends BundleField[Bool](MemTypeNC, Output(Bool()), _ := false.B)
 
 // Pass virtual address of upper level cache
 case object VaddrKey extends ControlKey[UInt]("vaddr")

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -46,6 +46,10 @@ case class L1Param
   val needResolveAlias = aliasBitsOpt.nonEmpty
 }
 
+// Pass uncached memory attribute from PBMT to MMIOBridge
+case object MemTypeNC extends ControlKey[Bool]("memType_NC")
+case class MemTypeNCField() extends BundleField[Bool](MemTypeNC, Output(Bool()), _ := true.B)
+
 // Pass virtual address of upper level cache
 case object VaddrKey extends ControlKey[UInt]("vaddr")
 case class VaddrField(width: Int) extends BundleField[UInt](VaddrKey, Output(UInt(width.W)), _ := 0.U(width.W))

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -46,9 +46,12 @@ case class L1Param
   val needResolveAlias = aliasBitsOpt.nonEmpty
 }
 
-// Pass uncached memory attribute from PBMT to MMIOBridge
-case object MemTypeNC extends ControlKey[Bool]("memType_NC")
-case class MemTypeNCField() extends BundleField[Bool](MemTypeNC, Output(Bool()), _ := false.B)
+// Pass PMA and uncached memory attribute from PBMT to MMIOBridge
+case object MemBackTypeMM extends ControlKey[Bool]("memBackType_MM")
+case class MemBackTypeMMField() extends BundleField[Bool](MemBackTypeMM, Output(Bool()), _ := false.B)
+
+case object MemPageTypeNC extends ControlKey[Bool]("memPageType_NC")
+case class MemPageTypeNCField() extends BundleField[Bool](MemPageTypeNC, Output(Bool()), _ := false.B)
 
 // Pass virtual address of upper level cache
 case object VaddrKey extends ControlKey[UInt]("vaddr")

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -74,6 +74,8 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   //          by the HN (Home Node) on bus with Endpoint Ordering.
   val bufferableNC = true
 
+  require(!bufferableNC || needRR , "DO NOT set 'bufferableNC = true' when 'needRR = false'")
+
   val io = IO(new Bundle() {
     val req = Flipped(DecoupledIO(new TLBundleA(edge.bundle)))
     val resp = DecoupledIO(new TLBundleD(edge.bundle))

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -26,7 +26,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.tilelink.TLMessages._
 import coupledL2.HasCoupledL2Parameters
-import coupledL2.MemTypeNC
+import coupledL2.{MemBackTypeMM, MemPageTypeNC}
 
 class MMIOBridge()(implicit p: Parameters) extends LazyModule
   with HasCoupledL2Parameters
@@ -51,7 +51,7 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
       supportsPutPartial = TransferSizes(1, 8)
     )),
     beatBytes = 8,
-    requestKeys = Seq(MemTypeNC)
+    requestKeys = Seq(MemBackTypeMM, MemPageTypeNC)
   )))
 
   lazy val module = new MMIOBridgeImp(this)
@@ -61,6 +61,17 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
 class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
   val needRR = true
+
+  // *NOTICE: DO NOT set 'bufferableNC = true' when 'needRR = false', 
+  //          since the ordering between NC and IO described in SvPBMT was maintained by 'fence iorw, iorw'.
+  //          And alias with NC and IO must not cause loss of coherency due to SvPBMT, which was NOT guaranteed
+  //          by CHI specification in which case obtaining different EWA from different agents.
+  //
+  //          1) For Memory backend, the observability of possible weakly-ordered intermediate states were determined
+  //          by the core (the processor pipeline, store buffer, etc.) because there is no ordering guarantee from HN.
+  //
+  //          2) For Device backend, the observability of possible weakly-ordered intermediate states were determined
+  //          by the HN (Home Node) on bus with Endpoint Ordering.
   val bufferableNC = true
 
   val io = IO(new Bundle() {
@@ -97,7 +108,8 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   val corrupt = Reg(Bool())
   val traceTag = Reg(Bool())
   val isRead = req.opcode === Get
-  val isNC = req.user.lift(MemTypeNC).getOrElse(false.B)
+  val isBackTypeMM = req.user.lift(MemBackTypeMM).getOrElse(false.B)
+  val isPageTypeNC = req.user.lift(MemPageTypeNC).getOrElse(false.B)
 
   val wordBits = io.req.bits.data.getWidth // 64
   val wordBytes = wordBits / 8
@@ -202,21 +214,30 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   txreq.bits.allowRetry := allowRetry
   txreq.bits.pCrdType := Mux(allowRetry, 0.U, pCrdType)
   txreq.bits.expCompAck := false.B
-  // *Ordering and MemAttr: [when 'bufferableNC' configured to true]
-  //    PBMT::NC    -> Non-cacheable Bufferable (weakly-ordered uncached)
-  //    PBMT::IO    -> Device nRnE (strongly-ordered uncached device)
-  //    PMA uncache -> Device nRnE (strongly-ordered uncached device)
+  // *Ordering and MemAttr: 
+  // ---------------------------------------------------------
+  // [when 'bufferableNC' configured to false]
+  //    PMA = MM   , PBMT = NC -> Non-cacheable Non-bufferable
+  //    PMA = MM   , PBMT = IO -> Non-cacheable Non-bufferable
+  //    PMA = NC/IO, PBMT = NC -> Device nRnE (no reorder, no early acknowlegment)
+  //    PMA = NC/IO, PBMT = IO -> Device nRnE (no reorder, no early acknowlegment)
+  // ---------------------------------------------------------
+  // [when 'bufferableNC' configured to true]
+  //    PMA = MM   , PBMT = NC -> Non-cacheable Bufferable
+  //    PMA = MM   , PBMT = IO -> Non-cacheable Bufferable
+  //    PMA = NC/IO, PBMT = NC -> Device nRE  (no reorder, early acknowlegment)
+  //    PMA = NC/IO, PBMT = IO -> Device nRnE (no reorder, no early acknowlegment)
   txreq.bits.order := {
     if (needRR) 
-      Mux(!isNC, OrderEncodings.EndpointOrder, OrderEncodings.RequestOrder)
+      Mux(!isBackTypeMM, OrderEncodings.EndpointOrder, OrderEncodings.RequestOrder)
     else 
       OrderEncodings.None
   }
   txreq.bits.memAttr := MemAttr(
     allocate = false.B,
     cacheable = false.B,
-    device = !isNC,
-    ewa = if (bufferableNC) isNC else false.B
+    device = !isBackTypeMM,
+    ewa = if (bufferableNC) (isPageTypeNC || isBackTypeMM) else false.B
   )
 
   io.resp.valid := !s_resp && Mux(isRead, w_compdata, w_comp && w_dbidresp && s_ncbwrdata)


### PR DESCRIPTION
* Added user field ```memType_NC``` to recognize **```NC```** type configured by Svpbmt, mapped to *****Non-cacheable Bufferable*****.

* Memory attributes other than **```NC```** are still mapped to *****Device nRnE***** in CHI specification.