### PR TITLE
fix(CMO): fix bugs for CMO ReleaseData when L1 miss L2 hit

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -840,6 +840,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     }.elsewhen (mp_cbwrdata_valid) {
       state.s_cbwrdata.get := true.B
       meta.state := INVALID
+      meta.dirty := false.B
     }.elsewhen (mp_probeack_valid) {
       state.s_probeack := true.B
     }.elsewhen (mp_dct_valid) {


### PR DESCRIPTION
* Read DS data and write ReleaseBuf if cmo clean/flush data miss L1 but hit L2
* Clean meta.dirty in MSHR when mp_cbwrdata_valid, avoid false assertion