### PR TITLE
fix(l2pf): fix some bugs and add some performance debugging means.

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -373,7 +373,7 @@ class TlbExceptionBundle extends Bundle {
   val instr = Output(Bool())
 }
 class L2TlbReq(implicit p: Parameters) extends L2Bundle{
-  val vaddr = Output(UInt((fullVAddrBits+offsetBits).W))
+  val vaddr = Output(UInt((fullVAddrBits).W))
   val cmd = Output(TlbCmd())
   val isPrefetch = Output(Bool())
   val size = Output(UInt(log2Ceil(log2Ceil(XLEN/8) + 1).W))

--- a/src/main/scala/coupledL2/TopDownMonitor.scala
+++ b/src/main/scala/coupledL2/TopDownMonitor.scala
@@ -111,31 +111,32 @@ class TopDownMonitor()(implicit p: Parameters) extends L2Module {
    */
   // prefetch accuracy calculation
   val l2prefetchSent = dirResultMatchVec(
-    r =>  !r.hit &&
-      (r.replacerInfo.reqSource === MemReqSource.Prefetch2L2BOP.id.U ||
-       r.replacerInfo.reqSource === MemReqSource.Prefetch2L2PBOP.id.U ||
-       r.replacerInfo.reqSource === MemReqSource.Prefetch2L2SMS.id.U ||
-       r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stride.id.U ||
-       r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stream.id.U ||
-       r.replacerInfo.reqSource === MemReqSource.Prefetch2L2TP.id.U)
+    r => (
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2BOP.id.U ||
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2PBOP.id.U ||
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2SMS.id.U ||
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stride.id.U ||
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stream.id.U ||
+      r.replacerInfo.reqSource === MemReqSource.Prefetch2L2TP.id.U
+    )
   )
   val l2prefetchSentBOP = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2BOP.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2BOP.id.U
   )
   val l2prefetchSentPBOP = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2PBOP.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2PBOP.id.U
   )
   val l2prefetchSentSMS = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2SMS.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2SMS.id.U
   )
   val l2prefetchSentStride = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stride.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stride.id.U
   )
   val l2prefetchSentStream = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stream.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2Stream.id.U
   )
   val l2prefetchSentTP = dirResultMatchVec(
-    r => !r.hit && r.replacerInfo.reqSource === MemReqSource.Prefetch2L2TP.id.U
+    r => r.replacerInfo.reqSource === MemReqSource.Prefetch2L2TP.id.U
   )
 
   val l2prefetchUseful = dirResultMatchVec(
@@ -169,6 +170,9 @@ class TopDownMonitor()(implicit p: Parameters) extends L2Module {
   val l2demandRequest = dirResultMatchVec(
     r => reqFromCPU(r)
   )
+  
+  // TODO: get difference prefetchSrc for detailed analysis
+  // FIXME lyq: it's abnormal l2prefetchLate / l2prefetchUseful is more than 1
   val l2prefetchLate = io.latePF
 
   // PF Accuracy

--- a/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
+++ b/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
@@ -143,7 +143,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
 
   val hartid = cacheParams.hartId
   // 0 / 1: whether to enable temporal prefetcher
-  private val enableTP = Constantin.createRecord("enableTP"+hartid.toString, initValue = 1)
+  private val enableTP = Constantin.createRecord("tp_enable"+hartid.toString, initValue = 1)
   // 0 ~ N: throttle cycles for each prefetch request
   private val tpThrottleCycles = Constantin.createRecord("tp_throttleCycles"+hartid.toString, initValue = 4)
   // 0 / 1: whether request to set as trigger on meta hit


### PR DESCRIPTION
1. fix the bug of prefetch statistics in TopDown
2. fix the bug of vaddr width and the bug of  bestScore initialization (default 0)
3. add some performance debugging means.
    1. use constantIn to control the enable signals of `Receiver`, `BOP`, `TP`
    2. use constantIn to control part of parameters of `BOP`
    3. add ChiselDB to record the prefetch footprints

The point that affects performance is that the initial value of the BOP prefetch score is changed from 10 to 0, which is used for stable initial training. The performance impact results are as follows.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9ba8f931-621b-4238-80d2-c9d69cc5b6e4">
