### PR TITLE
feat(TL2CHICoupledL2): support TraceTag

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -135,6 +135,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val expCompAck = chiOpt.map(_ => Bool())
   val allowRetry = chiOpt.map(_ => Bool())
   val memAttr = chiOpt.map(_ => new MemAttr)
+  val traceTag = chiOpt.map(_ => Bool())
 
   def toCHIREQBundle(): CHIREQ = {
     val req = WireInit(0.U.asTypeOf(new CHIREQ()))
@@ -231,6 +232,7 @@ class RespInfoBundle(implicit p: Parameters) extends L2Bundle
   val resp = chiOpt.map(_ => UInt(RESP_WIDTH.W))
   val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
   val respErr = chiOpt.map(_ => UInt(RESPERR_WIDTH.W))
+  val traceTag = chiOpt.map(_ => Bool())
 }
 
 class RespBundle(implicit p: Parameters) extends L2Bundle {

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -93,6 +93,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   val pCrdType = Reg(UInt(PCRDTYPE_WIDTH.W))
   val denied = Reg(Bool())
   val corrupt = Reg(Bool())
+  val traceTag = Reg(Bool())
   val isRead = req.opcode === Get
 
   val wordBits = io.req.bits.data.getWidth // 64
@@ -117,6 +118,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     allowRetry := true.B
     denied := false.B
     corrupt := false.B
+    traceTag := false.B
     when (io.req.bits.opcode === Get) {
       w_compdata := false.B
       w_readreceipt.foreach(_ := false.B)
@@ -155,6 +157,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       w_dbidresp := true.B
       srcID := rxrsp.bits.srcID
       dbID := rxrsp.bits.dbID
+      traceTag := rxrsp.bits.traceTag
     }
     when (rxrsp.bits.opcode === CompDBIDResp || rxrsp.bits.opcode === Comp) {
       denied := denied || rxrsp.bits.respErr === RespErrEncodings.NDERR
@@ -224,6 +227,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     List.tabulate(words)(i => i.U -> (ZeroExt(req.mask, BE_WIDTH) << (i * wordBytes)))
   )
   txdat.bits.data := Fill(words, req.data) & FillInterleaved(8, txdat.bits.be)
+  txdat.bits.traceTag := traceTag
 
   rxrsp.ready := (!w_comp || !w_dbidresp || !w_readreceipt.getOrElse(true.B)) && s_txreq
   rxdat.ready := !w_compdata && s_txreq

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -105,6 +105,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val gotPCrdGrant = RegInit(false.B)
   val denied = RegInit(false.B)
   val corrupt = RegInit(false.B)
+  val cbWrDataTraceTag = RegInit(false.B)
   val metaChi = ParallelLookUp(
     Cat(meta.dirty, meta.state),
     Seq(
@@ -141,6 +142,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     pcrdtype := 0.U
     denied := false.B
     corrupt := false.B
+    cbWrDataTraceTag := false.B
 
     retryTimes := 0.U
     backoffTimer := 0.U
@@ -291,13 +293,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       orsp.txnID := dbid
       orsp.dbID := 0.U
       orsp.opcode := CompAck
-//      orsp.resperr := 0.U
       orsp.resp  := 0.U
       orsp.fwdState := 0.U
-//      orsp.stashhit := 0.U
-//      orsp.datapull :=0.U
-//      orsp.pcrdtype := 0.U
-//      orsp.tracetag := 0.U
+      orsp.traceTag := req.traceTag.get
     }
 
   /*TXREQ for Transaction Request*/
@@ -491,6 +489,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cbwrdata.pCrdType.get := 0.U // TODO
     mp_cbwrdata.retToSrc.get := req.retToSrc.get // DontCare
     mp_cbwrdata.expCompAck.get := false.B
+    mp_cbwrdata.traceTag.get := cbWrDataTraceTag
     mp_cbwrdata
   }
 
@@ -503,11 +502,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_probeack.alias.foreach(_ := 0.U)
     mp_probeack.vaddr.foreach(_ := 0.U)
     mp_probeack.isKeyword.foreach(_ := false.B)
-    mp_probeack.opcode := 0.U /* Mux(
-      meta.dirty && isT(meta.state) || probeDirty || req.needProbeAckData,
-      ProbeAckData,
-      ProbeAck
-    ) */ // DontCare
+    mp_probeack.opcode := 0.U
     mp_probeack.param := DontCare
     mp_probeack.size := log2Ceil(blockBytes).U
     mp_probeack.sourceId := 0.U(sourceIdBits.W)
@@ -573,6 +568,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_probeack.pCrdType.get := 0.U
     mp_probeack.retToSrc.get := req.retToSrc.get // DontCare
     mp_probeack.expCompAck.get := false.B
+    mp_probeack.traceTag.get := req.traceTag.get
     mp_probeack.snpHitRelease := req.snpHitRelease
     mp_probeack.snpHitReleaseWithData := req.snpHitReleaseWithData
     mp_probeack.snpHitReleaseIdx := req.snpHitReleaseIdx
@@ -751,6 +747,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_dct.pCrdType.get := 0.U // DontCare
     mp_dct.retToSrc.get := false.B // DontCare
     mp_dct.expCompAck.get := false.B // DontCare
+    mp_dct.traceTag.get := req.traceTag.get
     mp_dct.snpHitRelease := req.snpHitRelease
     mp_dct.snpHitReleaseWithData := req.snpHitReleaseWithData
     mp_dct.snpHitReleaseIdx := req.snpHitReleaseIdx
@@ -919,6 +916,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       homenid := rxdat.bits.homeNID.getOrElse(0.U)
       denied := denied || nderr
       corrupt := corrupt || derr || nderr
+      req.traceTag.get := req.traceTag.get || rxdat.bits.traceTag.getOrElse(false.B)
     }
   }
 
@@ -931,6 +929,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       homenid := rxrsp.bits.srcID.getOrElse(0.U)
       dbid := rxrsp.bits.dbID.getOrElse(0.U)
       denied := denied || nderr
+      req.traceTag.get := rxrsp.bits.traceTag.get
     }
 
     when (rxrsp.bits.chiOpcode.get === Comp) {
@@ -942,11 +941,13 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         gotT := rxrspIsU
         gotDirty := false.B
         denied := denied || nderr
+        req.traceTag.get := rxrsp.bits.traceTag.get
       }
 
       // There is a pending Evict transaction waiting for the Comp resp
       when (!state.w_releaseack) {
         state.w_releaseack := true.B
+        // There is no CompAck for Comp in response of Evict. Thus there is no need to record TraceTag.
       }
 
       // Comp for Dataless transaction that include CompAck
@@ -958,6 +959,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       state.w_releaseack := true.B
       srcid := rxrsp.bits.srcID.getOrElse(0.U)
       dbid := rxrsp.bits.dbID.getOrElse(0.U)
+      cbWrDataTraceTag := rxrsp.bits.traceTag.get
     }
     when (rxrsp.bits.chiOpcode.get === RetryAck) {
       srcid := rxrsp.bits.srcID.getOrElse(0.U)

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -62,6 +62,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   io.in.respInfo.resp.get      := io.out.bits.resp
   io.in.respInfo.pCrdType.get  := DontCare // RXDAT Channel does not have a pCrdType field
   io.in.respInfo.respErr.get   := io.out.bits.respErr
+  io.in.respInfo.traceTag.get  := io.out.bits.traceTag
 
   io.out.ready := true.B
 

--- a/src/main/scala/coupledL2/tl2chi/RXRSP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXRSP.scala
@@ -49,6 +49,7 @@ class RXRSP(implicit p: Parameters) extends TL2CHIL2Module {
   io.in.respInfo.pCrdType.get  := io.out.bits.pCrdType
   io.in.respInfo.respErr.get   := io.out.bits.respErr
   io.in.respInfo.last          := true.B
+  io.in.respInfo.traceTag.get  := io.out.bits.traceTag
 
   io.out.ready := true.B
 

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -95,7 +95,9 @@ class RXSNP(
   }
 
   val STALL_CNT_MAX = 28000.U
-  assert(stallCnt <= STALL_CNT_MAX, "stallCnt full! maybe there is a deadlock! addr => 0x%x req_opcode => %d txn_id => %d", rxsnp.bits.addr, rxsnp.bits.opcode, rxsnp.bits.txnID);
+  assert(stallCnt <= STALL_CNT_MAX,
+    "stallCnt full! maybe there is a deadlock! addr => 0x%x req_opcode => %d txn_id => %d",
+    rxsnp.bits.addr, rxsnp.bits.opcode, rxsnp.bits.txnID)
 
   assert(!(stall && rxsnp.fire))
 
@@ -146,6 +148,7 @@ class RXSNP(
     task.chiOpcode.foreach(_ := snp.opcode)
     task.pCrdType.foreach(_ := 0.U)
     task.retToSrc.foreach(_ := snp.retToSrc)
+    task.traceTag.foreach(_ := snp.traceTag)
     task
   }
 

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -141,6 +141,7 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module {
     dat.data := beat
     dat.resp := task.resp.get
     dat.fwdState := task.fwdState.get
+    dat.traceTag := task.traceTag.get
 
     dat
   }

--- a/src/main/scala/coupledL2/tl2chi/TXRSP.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXRSP.scala
@@ -88,6 +88,7 @@ class TXRSP(implicit p: Parameters) extends TL2CHIL2Module {
     rsp.opcode := task.chiOpcode.get
     rsp.resp := task.resp.get
     rsp.fwdState := task.fwdState.get
+    rsp.traceTag := task.traceTag.get
     // TODO: Finish this
     rsp
   }


### PR DESCRIPTION
According to CHI issue E.b spec, a component that receives a packet with a TraceTag bit set in every received packet must preserve and reflect the value back in any response packet or spawned packet generated in response to the received packet. This commit specifies the Request-Response pairs that should follow this rule, including:

* A snoop response (including DCT response), with or without data, in response to a snoop request.
* A CompAck from RN in response to CompData, Comp, or RespSepData.
* A write data in response to DBIDResp, DBIDRespOrd, or CompDBIDResp.