### PR TITLE
fix(MSHR, RXSNP): handle nested snoop on WriteCleanFull

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -117,6 +117,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   // Used for get data from ReleaseBuf when snoop hit with same PA 
   val snpHitRelease = Bool()
+  val snpHitReleaseToB = Bool()
   val snpHitReleaseWithData = Bool()
   val snpHitReleaseIdx = UInt(mshrBits.W) 
   // CHI

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -239,6 +239,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.aMergeTask       := req_s3.aMergeTask
   ms_task.txChannel        := 0.U
   ms_task.snpHitRelease    := false.B
+  ms_task.snpHitReleaseToB := false.B
   ms_task.snpHitReleaseWithData := false.B
   ms_task.snpHitReleaseIdx := 0.U
   ms_task.denied           := false.B

--- a/src/main/scala/coupledL2/tl2tl/SinkB.scala
+++ b/src/main/scala/coupledL2/tl2tl/SinkB.scala
@@ -50,6 +50,7 @@ class SinkB(implicit p: Parameters) extends L2Module {
     task.wayMask := Fill(cacheParams.ways, "b1".U)
     task.reqSource := MemReqSource.NoWhere.id.U // Ignore
     task.snpHitRelease := false.B
+    task.snpHitReleaseToB := false.B
     task.snpHitReleaseWithData := false.B
     task.snpHitReleaseIdx := 0.U
     task


### PR DESCRIPTION
* Never exclude release toB (WriteCleanFull) on nested write back.

* Allow meta write on release toB nested snoops.