### PR TITLE
chore(workflow): switch runner to ubuntu-22.04 for CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   tl-test_L2:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Environments
     env:


### PR DESCRIPTION
In this update, we have changed the GitHub Actions CI runner from ubuntu-latest to ubuntu-22.04 for the following reasons:

- ubuntu-latest currently points to Ubuntu 24.04.
- ubuntu-24.04 is missing the SQLite3 environment, which caused the CI tasks that previously worked to fail.
- Switching to ubuntu-22.04 ensures that the SQLite3 environment is available and functional, resolving this compatibility issue.

see [more details](https://github.com/actions/runner-images/issues/10636).