### PR TITLE
fix(MainPipe): write ReleaseBuffer on ```cbo.inval```

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -398,7 +398,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val need_data_a = dirResult_s3.hit && (req_get_s3 || req_acquireBlock_s3)
   val need_data_b = sinkB_req_s3 && (doRespData || doFwd || dirResult_s3.hit && meta_s3.state === TRUNK)
   val need_data_mshr_repl = mshr_refill_s3 && need_repl && !retry
-  val need_data_cmo = cmo_cbo_retention_s3 && dirResult_s3.hit && meta_s3.dirty
+  val need_data_cmo = cmo_cbo_s3 && dirResult_s3.hit && meta_s3.dirty
   val ren = need_data_a || need_data_b || need_data_mshr_repl || need_data_cmo
 
   val wen_c = sinkC_req_s3 && isParamFromT(req_s3.param) && req_s3.opcode(0) && dirResult_s3.hit


### PR DESCRIPTION
* **```Evict```** derived from ```cbo.inval``` might be nested by snoop from other RNs, and forwarding of nested snoop from ReleaseBuffer should always be available before CMO completion was acknownleged, so data must also be written to ReleaseBuffer when ```cbo.inval``` entered MainPipe on the first time.

* Data should be preserved before CMO completion was acknowledged. Otherwise, the nested snoops were possible to get too-old data, which was not expected under any circumstance, since the data was possible to be excluded from lower-level caches and was transfered between multiple RNs only through multiple DCTs.