### PR TITLE
fix(MSHR): moved ReleaseBuffer read determination into MSHR

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -81,6 +81,9 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val useProbeData = Bool()               // data source, true for ReleaseBuf and false for RefillBuf
   val mshrRetry = Bool()                  // is retry task for mshr conflict
 
+  val readProbeDataDown = Bool()          // whether data from ReleaseBuf was needed on mainpipe by downward operations
+                                          // reads by upwards was handled in RequestArb by 'mshrTask_s2_a_upwards'
+
   // For Intent
   val fromL2pft = prefetchOpt.map(_ => Bool()) // Is the prefetch req from L2(BOP) or from L1 prefetch?
                                           // If true, MSHR should send an ack to L2 prefetcher.

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -250,14 +250,10 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val snpHitReleaseNeedData = if (enableCHI) {
     !mshrTask_s2 && task_s2.bits.fromB && task_s2.bits.snpHitReleaseWithData
   } else false.B
-  io.releaseBufRead_s2.valid := Mux(
+  io.releaseBufRead_s2.valid := task_s2.valid && Mux(
     mshrTask_s2,
-    releaseNeedData ||
-      snoopNeedData ||
-      dctNeedData ||
-      cmoNeedData ||
-      mshrTask_s2_a_upwards && task_s2.bits.useProbeData,
-    task_s2.valid && snpHitReleaseNeedData
+    task_s2.bits.readProbeDataDown || mshrTask_s2_a_upwards && task_s2.bits.useProbeData,
+    snpHitReleaseNeedData
   )
   io.releaseBufRead_s2.bits.id := Mux(
     task_s2.bits.snpHitRelease,

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -196,6 +196,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     // mp_release definitely read releaseBuf and refillBuf at ReqArb
     // and it needs to write refillData to DS, so useProbeData is set false according to DS.wdata logic
     mp_release.useProbeData := false.B
+    mp_release.readProbeDataDown := mp_release.opcode === ReleaseData
     mp_release.mshrRetry := false.B
     mp_release.way := dirResult.way
     mp_release.fromL2pft.foreach(_ := false.B)
@@ -245,6 +246,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_probeack.mshrId := io.id
     mp_probeack.aliasTask.foreach(_ := false.B)
     mp_probeack.useProbeData := true.B // write [probeAckData] to DS, if not probed toN
+    mp_probeack.readProbeDataDown := mp_probeack.opcode === ProbeAckData
     mp_probeack.mshrRetry := false.B
     mp_probeack.way := dirResult.way
     mp_probeack.fromL2pft.foreach(_ := false.B)
@@ -328,6 +330,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
       (req.aliasTask.getOrElse(false.B) && 
         !(dirResult.meta.state === BRANCH && req_needT) 
       )
+    mp_grant.readProbeDataDown := false.B
     mp_grant.dirty := false.B
 
     mp_grant.meta := MetaEntry(

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -222,6 +222,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.mshrId           := 0.U(mshrBits.W)
   ms_task.aliasTask.foreach(_ := cache_alias)
   ms_task.useProbeData     := false.B
+  ms_task.readProbeDataDown := false.B
   ms_task.mshrRetry        := false.B
   ms_task.fromL2pft.foreach(_ := req_s3.fromL2pft.get)
   ms_task.needHint.foreach(_  := req_s3.needHint.get)


### PR DESCRIPTION
* ReleaseBuffer read should not be determined by probeack opcode of SnpResp or SnpRespData.