### PR TITLE
fix(MainPipe): reject state update on nested SnpStashX

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -123,6 +123,8 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val snpHitReleaseToB = Bool()
   val snpHitReleaseWithData = Bool()
   val snpHitReleaseIdx = UInt(mshrBits.W) 
+  val snpHitReleaseMetaState = UInt(2.W)
+  val snpHitReleaseMetaDirty = Bool()
   // CHI
   val tgtID = chiOpt.map(_ => UInt(TGTID_WIDTH.W))
   val srcID = chiOpt.map(_ => UInt(SRCID_WIDTH.W))
@@ -200,6 +202,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle with HasTLChannelBits {
 
   val metaTag = UInt(tagBits.W)
   val metaState = UInt(stateBits.W)
+  val metaDirty = Bool()
   val dirHit = Bool()
 
   // to drop duplicate prefetch reqs

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -809,6 +809,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_dct.snpHitReleaseToB := req.snpHitReleaseToB
     mp_dct.snpHitReleaseWithData := req.snpHitReleaseWithData
     mp_dct.snpHitReleaseIdx := req.snpHitReleaseIdx
+    mp_dct.snpHitReleaseMetaState := req.snpHitReleaseMetaState
+    mp_dct.snpHitReleaseMetaDirty := req.snpHitReleaseMetaDirty
 
     mp_dct
   }
@@ -1131,6 +1133,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.dirHit := dirResult.hit
   io.msInfo.bits.metaTag := dirResult.tag
   io.msInfo.bits.metaState := meta.state
+  io.msInfo.bits.metaDirty := meta.dirty
   io.msInfo.bits.willFree := will_free
   io.msInfo.bits.isAcqOrPrefetch := req_acquire || req_prefetch
   io.msInfo.bits.isPrefetch := req_prefetch

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -93,6 +93,15 @@ class RXSNP(
     )).asUInt
   val replaceDataMask = VecInit(io.msInfo.map(_.bits.replaceData)).asUInt
 
+  val replaceNestSnpMetaState = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
+    Mux(hit, ms.bits.metaState, 0.U)
+  }})
+  val replaceNestSnpMetaDirty = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
+    Mux(hit, ms.bits.metaDirty, false.B)
+  }})
+
+  assert(PopCount(replaceNestSnpMask) <= 1.U, "multiple replace nest snoop")
+
   task := fromSnpToTaskBundle(rxsnp.bits)
 
   val stall = reqBlockSnp || replaceBlockSnp || cmoBlockSnp // addrConflict || replaceConflict
@@ -152,6 +161,8 @@ class RXSNP(
     task.snpHitRelease := replaceNestSnpMask.orR
     task.snpHitReleaseToB := releaseToBNestSnpMask.orR
     task.snpHitReleaseWithData := (replaceNestSnpMask & replaceDataMask).orR
+    task.snpHitReleaseMetaState := replaceNestSnpMetaState
+    task.snpHitReleaseMetaDirty := replaceNestSnpMetaDirty
     task.snpHitReleaseIdx := PriorityEncoder(replaceNestSnpMask)
     task.tgtID.foreach(_ := 0.U) // TODO
     task.srcID.foreach(_ := snp.srcID)

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -573,6 +573,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.replaceData := mp_release.opcode === ReleaseData
   io.msInfo.bits.releaseToB := false.B
   io.msInfo.bits.metaState := meta.state
+  io.msInfo.bits.metaDirty := meta.dirty
   io.msInfo.bits.channel := req.channel
 
   assert(!(c_resp.valid && !io.status.bits.w_c_resp))

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -243,6 +243,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.snpHitReleaseToB := false.B
   ms_task.snpHitReleaseWithData := false.B
   ms_task.snpHitReleaseIdx := 0.U
+  ms_task.snpHitReleaseMetaState := 0.U
+  ms_task.snpHitReleaseMetaDirty := false.B
   ms_task.denied           := false.B
   ms_task.corrupt          := false.B
 

--- a/src/main/scala/coupledL2/tl2tl/SinkB.scala
+++ b/src/main/scala/coupledL2/tl2tl/SinkB.scala
@@ -53,6 +53,8 @@ class SinkB(implicit p: Parameters) extends L2Module {
     task.snpHitReleaseToB := false.B
     task.snpHitReleaseWithData := false.B
     task.snpHitReleaseIdx := 0.U
+    task.snpHitReleaseMetaState := 0.U
+    task.snpHitReleaseMetaDirty := false.B
     task
   }
   val task = fromTLBtoTaskBundle(io.b.bits)


### PR DESCRIPTION
* Never allow ```b_inv_dirty``` (Invalidating WriteBack state inside MSHR by nested Snoops) on SnpStash* and other future snoops that would leave cache lin state untouched.

* Use cache line states in nested MSHR on nested SnpStash* other than that from MainPipe.