### PR TITLE
fix(MSHR, MainPipe, RXSNP): fix bugs in SnpOnce*-writeback nesting

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -321,6 +321,8 @@ class NestedWriteback(implicit p: Parameters) extends L2Bundle {
   val tag = UInt(tagBits.W)
   // Nested ReleaseData sets block dirty
   val c_set_dirty = Bool()
+  // Nested Release sets block TIP
+  val c_set_tip = Bool()
   // Nested Snoop invalidates block
   val b_inv_dirty = Bool()
 

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -123,8 +123,8 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val snpHitReleaseToB = Bool()
   val snpHitReleaseWithData = Bool()
   val snpHitReleaseIdx = UInt(mshrBits.W) 
-  val snpHitReleaseMetaState = UInt(2.W)
-  val snpHitReleaseMetaDirty = Bool()
+  val snpHitReleaseState = UInt(2.W)
+  val snpHitReleaseDirty = Bool()
   // CHI
   val tgtID = chiOpt.map(_ => UInt(TGTID_WIDTH.W))
   val srcID = chiOpt.map(_ => UInt(SRCID_WIDTH.W))
@@ -203,6 +203,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle with HasTLChannelBits {
   val metaTag = UInt(tagBits.W)
   val metaState = UInt(stateBits.W)
   val metaDirty = Bool()
+  val probeDirty = Bool()
   val dirHit = Bool()
 
   // to drop duplicate prefetch reqs

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -203,8 +203,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode) || req_chiOpcode === SnpOnce)
   // doRespData_once includes SnpOnceFwd(nested) UD -> I and SnpOnce UC -> UC/I(non-nested/nested)
   // TODO: too ugly, any better way?
-  val doRespData_once = req.snpHitRelease && req.snpHitReleaseMetaDirty && req_chiOpcode === SnpOnceFwd ||
-                        (dirResult.hit && !meta.dirty || req.snpHitRelease && !req.snpHitReleaseMetaDirty) && req_chiOpcode === SnpOnce
+  val doRespData_once = req.snpHitRelease && req.snpHitReleaseWithData && req.snpHitReleaseMetaDirty && req_chiOpcode === SnpOnceFwd ||
+                        (dirResult.hit && !meta.dirty || req.snpHitRelease && req.snpHitReleaseWithData && !req.snpHitReleaseMetaDirty) && req_chiOpcode === SnpOnce
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
   dontTouch(doRespData_dirty)
@@ -288,7 +288,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     req_chiOpcode === SnpUniqueStash ||
     req_chiOpcode === SnpCleanShared ||
     req_chiOpcode === SnpCleanInvalid ||
-    isSnpOnceX(req_chiOpcode) && req.snpHitRelease && req.snpHitReleaseMetaDirty
+    isSnpOnceX(req_chiOpcode) && req.snpHitRelease && req.snpHitReleaseWithData && req.snpHitReleaseMetaDirty
   )
   val fwdCacheState = Mux(
     isSnpToBFwd(req_chiOpcode),

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -201,7 +201,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     (isSnpToBFwd(req_chiOpcode) /*|| isSnpToNFwd(req_chiOpcode)*/)
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && dirResult.hit && meta.state === BRANCH && 
     (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode))
-  val doRespData_once = dirResult.hit && meta.state === TRUNK && isSnpOnceX(req_chiOpcode)
+  val doRespData_once = hitDirty && isSnpOnceX(req_chiOpcode)
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
   dontTouch(doRespData_dirty)
@@ -282,14 +282,16 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     req_chiOpcode === SnpUnique ||
     req_chiOpcode === SnpUniqueStash ||
     req_chiOpcode === SnpCleanShared ||
-    req_chiOpcode === SnpCleanInvalid
+    req_chiOpcode === SnpCleanInvalid ||
+    req_chiOpcode === SnpOnce ||
+    req_chiOpcode === SnpOnceFwd
   )
   val fwdCacheState = Mux(
     isSnpToBFwd(req_chiOpcode),
     SC,
     Mux(isSnpToNFwd(req_chiOpcode), UC /*UC_UD*/, I)
   )
-  val fwdPassDirty = isSnpToNFwd(req_chiOpcode) && hitDirtyOrWriteBack
+  val fwdPassDirty = (isSnpToNFwd(req_chiOpcode) || isSnpOnceX(req_chiOpcode)) && hitDirtyOrWriteBack
 
   /*TXRSP for CompAck */
     val txrsp_task = {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1186,6 +1186,10 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
     }
+    when (io.nestedwb.c_set_tip) {
+      meta.state := TIP
+      meta.clients := Fill(clientBits, false.B)
+    }
     when (io.nestedwb.b_inv_dirty && req.fromA) {
       meta.dirty := false.B
       meta.state := INVALID

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -203,13 +203,13 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && (
     dirResult.hit && meta.state === BRANCH &&
       (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode) || isSnpOnce(req_chiOpcode)) ||
-    hitWriteBack && req.snpHitReleaseMetaState === BRANCH &&
+    hitWriteBack && req.snpHitReleaseState === BRANCH &&
        isSnpOnce(req_chiOpcode))
   // doRespData_once includes SnpOnceFwd(nested) UD -> I and SnpOnce UC -> UC/I(non-nested/nested)
-  val doRespData_once = hitWriteBack && req.snpHitReleaseMetaDirty &&
+  val doRespData_once = hitWriteBack && req.snpHitReleaseDirty &&
       isSnpOnceFwd(req_chiOpcode) ||
     (dirResult.hit && !meta.dirty && meta.state =/= BRANCH ||
-      hitWriteBack && !req.snpHitReleaseMetaDirty && req.snpHitReleaseMetaState =/= BRANCH) &&
+      hitWriteBack && !req.snpHitReleaseDirty && req.snpHitReleaseState =/= BRANCH) &&
       isSnpOnce(req_chiOpcode)
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
@@ -294,7 +294,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     req_chiOpcode === SnpUniqueStash ||
     req_chiOpcode === SnpCleanShared ||
     req_chiOpcode === SnpCleanInvalid ||
-    isSnpOnceX(req_chiOpcode) && hitWriteBack && req.snpHitReleaseMetaDirty
+    isSnpOnceX(req_chiOpcode) && hitWriteBack && req.snpHitReleaseDirty
   )
   val fwdCacheState = Mux(
     isSnpToBFwd(req_chiOpcode),
@@ -822,8 +822,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_dct.snpHitReleaseToB := req.snpHitReleaseToB
     mp_dct.snpHitReleaseWithData := req.snpHitReleaseWithData
     mp_dct.snpHitReleaseIdx := req.snpHitReleaseIdx
-    mp_dct.snpHitReleaseMetaState := req.snpHitReleaseMetaState
-    mp_dct.snpHitReleaseMetaDirty := req.snpHitReleaseMetaDirty
+    mp_dct.snpHitReleaseState := req.snpHitReleaseState
+    mp_dct.snpHitReleaseDirty := req.snpHitReleaseDirty
 
     mp_dct
   }
@@ -1147,6 +1147,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.metaTag := dirResult.tag
   io.msInfo.bits.metaState := meta.state
   io.msInfo.bits.metaDirty := meta.dirty
+  io.msInfo.bits.probeDirty := probeDirty
   io.msInfo.bits.willFree := will_free
   io.msInfo.bits.isAcqOrPrefetch := req_acquire || req_prefetch
   io.msInfo.bits.isPrefetch := req_prefetch

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -200,7 +200,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val doRespData_retToSrc_fwd = req.retToSrc.get && 
     (isSnpToBFwd(req_chiOpcode) /*|| isSnpToNFwd(req_chiOpcode)*/)
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && dirResult.hit && meta.state === BRANCH && 
-    (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode))
+    (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode) || req_chiOpcode === SnpOnce)
   val doRespData_once = dirResult.hit && isSnpOnceX(req_chiOpcode)
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -201,7 +201,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     (isSnpToBFwd(req_chiOpcode) /*|| isSnpToNFwd(req_chiOpcode)*/)
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && dirResult.hit && meta.state === BRANCH && 
     (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode))
-  val doRespData_once = hitDirty && isSnpOnceX(req_chiOpcode)
+  val doRespData_once = dirResult.hit && isSnpOnceX(req_chiOpcode)
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
   dontTouch(doRespData_dirty)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -201,8 +201,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     (isSnpToBFwd(req_chiOpcode) /*|| isSnpToNFwd(req_chiOpcode)*/)
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && dirResult.hit && meta.state === BRANCH && 
     (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode))
-  val doRespData_onceFwd = dirResult.hit && meta.state === TRUNK && isSnpOnceFwd(req_chiOpcode)
-  val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_onceFwd
+  val doRespData_once = dirResult.hit && meta.state === TRUNK && isSnpOnceX(req_chiOpcode)
+  val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
   dontTouch(doRespData_dirty)
   dontTouch(doRespData_retToSrc_fwd)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -295,7 +295,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     SC,
     Mux(isSnpToNFwd(req_chiOpcode), UC /*UC_UD*/, I)
   )
-  val fwdPassDirty = (isSnpToNFwd(req_chiOpcode) || isSnpOnceX(req_chiOpcode)) && hitDirtyOrWriteBack
+  val fwdPassDirty = isSnpToNFwd(req_chiOpcode) && hitDirtyOrWriteBack
 
   /*TXRSP for CompAck */
     val txrsp_task = {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -201,7 +201,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     (isSnpToBFwd(req_chiOpcode) /*|| isSnpToNFwd(req_chiOpcode)*/)
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && dirResult.hit && meta.state === BRANCH && 
     (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode))
-  val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd
+  val doRespData_onceFwd = dirResult.hit && meta.state === TRUNK && isSnpOnceFwd(req_chiOpcode)
+  val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_onceFwd
 
   dontTouch(doRespData_dirty)
   dontTouch(doRespData_retToSrc_fwd)

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -328,9 +328,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     // *NOTICE: On Stash, the cache state must maintain unchanged on nested WriteBack
     when (isSnpStashX(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
-        req_s3.snpHitReleaseMetaState === BRANCH,
+        req_s3.snpHitReleaseState === BRANCH,
         SC,
-        Mux(req_s3.snpHitReleaseMetaDirty, UD, UC)
+        Mux(req_s3.snpHitReleaseDirty, UD, UC)
       )
     }
   }

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -606,6 +606,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData && task_s3.bits.param === TtoN
+  io.nestedwb.c_set_tip := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === Release && task_s3.bits.param === TtoN
   /**
     * Snoop nesting happens when:
     * 1. snoop nests a copy-back request

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -93,11 +93,11 @@ class RXSNP(
     )).asUInt
   val replaceDataMask = VecInit(io.msInfo.map(_.bits.replaceData)).asUInt
 
-  val replaceNestSnpMetaState = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
+  val replaceNestSnpState = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
     Mux(hit, ms.bits.metaState, 0.U)
   }})
-  val replaceNestSnpMetaDirty = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
-    Mux(hit, ms.bits.metaDirty, false.B)
+  val replaceNestSnpDirty = ParallelOR(io.msInfo.zip(replaceNestSnpMask.asBools).map { case (ms, hit) => {
+    Mux(hit, ms.bits.metaDirty || ms.bits.probeDirty, false.B)
   }})
 
   assert(PopCount(replaceNestSnpMask) <= 1.U, "multiple replace nest snoop")
@@ -161,8 +161,8 @@ class RXSNP(
     task.snpHitRelease := replaceNestSnpMask.orR
     task.snpHitReleaseToB := releaseToBNestSnpMask.orR
     task.snpHitReleaseWithData := (replaceNestSnpMask & replaceDataMask).orR
-    task.snpHitReleaseMetaState := replaceNestSnpMetaState
-    task.snpHitReleaseMetaDirty := replaceNestSnpMetaDirty
+    task.snpHitReleaseState := replaceNestSnpState
+    task.snpHitReleaseDirty := replaceNestSnpDirty
     task.snpHitReleaseIdx := PriorityEncoder(replaceNestSnpMask)
     task.tgtID.foreach(_ := 0.U) // TODO
     task.srcID.foreach(_ := snp.srcID)

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -188,6 +188,10 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
     opcode === SnpUniqueFwd 
   }
 
+  def isSnpOnceFwd(opcode: UInt): Bool = {
+    opcode === SnpOnceFwd
+  }
+
   def isSnpUniqueX(opcode: UInt): Bool = {
     opcode === SnpUnique || opcode === SnpUniqueFwd || opcode === SnpUniqueStash
   }

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -144,6 +144,14 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
     opcode === SnpOnce || opcode === SnpOnceFwd
   }
 
+  def isSnpOnce(opcode: UInt): Bool = {
+    opcode === SnpOnce
+  }
+
+  def isSnpOnceFwd(opcode: UInt): Bool = {
+    opcode === SnpOnceFwd
+  }
+
   def isSnpCleanX(opcode: UInt): Bool = {
     opcode === SnpClean || opcode === SnpCleanFwd
   }

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -188,10 +188,6 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
     opcode === SnpUniqueFwd 
   }
 
-  def isSnpOnceFwd(opcode: UInt): Bool = {
-    opcode === SnpOnceFwd
-  }
-
   def isSnpUniqueX(opcode: UInt): Bool = {
     opcode === SnpUnique || opcode === SnpUniqueFwd || opcode === SnpUniqueStash
   }

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -574,6 +574,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.releaseToB := false.B
   io.msInfo.bits.metaState := meta.state
   io.msInfo.bits.metaDirty := meta.dirty
+  io.msInfo.bits.probeDirty := probeDirty
   io.msInfo.bits.channel := req.channel
 
   assert(!(c_resp.valid && !io.status.bits.w_c_resp))

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -243,8 +243,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.snpHitReleaseToB := false.B
   ms_task.snpHitReleaseWithData := false.B
   ms_task.snpHitReleaseIdx := 0.U
-  ms_task.snpHitReleaseMetaState := 0.U
-  ms_task.snpHitReleaseMetaDirty := false.B
+  ms_task.snpHitReleaseState := 0.U
+  ms_task.snpHitReleaseDirty := false.B
   ms_task.denied           := false.B
   ms_task.corrupt          := false.B
 

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -438,6 +438,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData
+  io.nestedwb.c_set_tip := false.B
   io.nestedwb.b_inv_dirty := false.B
 
   io.nestedwbData := c_releaseData_s3.asTypeOf(new DSBlock)

--- a/src/main/scala/coupledL2/tl2tl/SinkB.scala
+++ b/src/main/scala/coupledL2/tl2tl/SinkB.scala
@@ -53,8 +53,8 @@ class SinkB(implicit p: Parameters) extends L2Module {
     task.snpHitReleaseToB := false.B
     task.snpHitReleaseWithData := false.B
     task.snpHitReleaseIdx := 0.U
-    task.snpHitReleaseMetaState := 0.U
-    task.snpHitReleaseMetaDirty := false.B
+    task.snpHitReleaseState := 0.U
+    task.snpHitReleaseDirty := false.B
     task
   }
   val task = fromTLBtoTaskBundle(io.b.bits)


### PR DESCRIPTION
This PR, which fixes bugs concerning SnpOnceX-writeback nesting, is based on following table:

| Opcode | Initial State | Final State | RetToSrc | Snoop response | snpHitRelease
| :---: | :---: | :---: | :---: | --- | :---: |
| SnpOnce | I | I | X | SnpResp_I | 0 |
| | UC | UC | X | SnpRespData_UC | 0 |
| | UD | UD | X | SnpRespData_UD | 0 |
| | SC | SC | 0 | SnpResp_SC | 0 |
| | SC | SC | 1 | SnpRespData_SC | 0 |
| SnpOnceFwd | I | I | 0 | SnpResp_I | 0 |
| | UC | UC | 0 | SnpResp_UC_Fwded_I | 0 |
| | UD | UD | 0 | SnpResp_UD_Fwded_I | 0 |
| | SC | SC | 0 | SnpResp_SC_Fwded_I | 0 |
| SnpOnce | I | I | X | SnpResp_I | 1 |
| | UC | I | X | SnpRespData_I | 1 |
| | UD | I | X | SnpRespData_I_PD | 1 |
| | SC | I | 0 | SnpResp_I | 1 |
| | SC | I | 1 | SnpRespData_I | 1 |
| SnpOnceFwd | I | I | 0 | SnpResp_I | 1 |
| | UC | I | 0 | SnpResp_I_Fwded_I | 1 |
| | UD | I | 0 | SnpRespData_I_PD_Fwded_I | 1 |
| | SC | I | 0 | SnpResp_I_Fwded_I | 1 |

In this pr, following changes are made:
* SnpOnce(L2) always response to HN with data when initial cache state is UC
    * Under SnpOnce-writeback nesting condition, we determine let SnpOnce(L2) response with data to HN
    * To keep in pace, without nesting,  SnpOnce(L2) also response with data to HN
   
* Add operations of SnpOnceX-writeback nesting
    * Under SnpOnceX-writeback nesting condition, final cache state(response cache state) will always be set to I
    * Under SnpOnceX-writeback nesting condition, L2 response with PD to HN, iff  initial cache state is UD
    * Under SnpOnceFwd-writeback nesting condition, L2 response with data to HN, iff initial cache state is UD

* Code(MSHR): operations of SnpOnceX response are separated into 3 categories:
       doRespData_dirty: opcode = SnpOnce && initial cache state = UD 
       doRespData_retToSrc_nonFwd:  opcode = SnpOnce && initial cache state = SC
       doRespData_once:  opcode = SnpOnce && initial cache state = UC, and opcode = SnpOnce Fwd && initial cache state = UD 
 
* Add operations of writeback-Snp nesting
    * Under writeback-Snp nesting condition, corresponding dir(meta) entry should be set as following:
        meta_state = TIP
        clients = 0

* In RXSNP: nested SnoopX dirty should include two condition: meta dirty and probe dirty(the latter was misses)

Bug fixed:
* When SnpOnceFwd/SnpOnce nests writeback, CopyBackWrData(Dirty) will be set as invalid, and SnpOnceFwd would not response data to HN, and the peer-RNs neither keep data because opcode is SnpOnceFwd. 
Therefore, the dirty data will be kept in neither HN, nor RNs. L3 will response error data to L2 in later operations(e.g. Grant)
* When writeback nests Snp(e.g. SnpOnce), SnpOnce will not set cache meta_state to TIP.
 As a result, following operations may not correctly change cache state(e.g. if followed by SnpUnique, cache state will not be set to INVALID bu SnpUnique, because the current state is TRUNK, not TIP). 
Then, next time L1 acquire L2, L1 will wrongly get permission from L2 without L2 acquiring L3