### PR TITLE
feat(MSHR): support WriteEvictOrEvict on eviction

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -138,6 +138,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val fwdState = chiOpt.map(_ => UInt(FWDSTATE_WIDTH.W))
   val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
   val retToSrc = chiOpt.map(_ => Bool()) // only used in snoop
+  val likelyshared = chiOpt.map(_ => Bool())
   val expCompAck = chiOpt.map(_ => Bool())
   val allowRetry = chiOpt.map(_ => Bool())
   val memAttr = chiOpt.map(_ => new MemAttr)
@@ -154,6 +155,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
     req.allowRetry := allowRetry.getOrElse(true.B)  //TODO: consider retry
     req.pCrdType := pCrdType.getOrElse(0.U)
     req.expCompAck := expCompAck.getOrElse(false.B)
+    req.likelyshared := likelyshared.getOrElse(false.B)
     req.memAttr := memAttr.getOrElse(MemAttr())
     req.snpAttr := true.B
     req.order := OrderEncodings.None

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -216,6 +216,8 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val releaseRefillData = task_s2.bits.replTask && (if (enableCHI) {
     task_s2.bits.toTXREQ && (
       task_s2.bits.chiOpcode.get === WriteBackFull ||
+      task_s2.bits.chiOpcode.get === WriteEvictFull ||
+      task_s2.bits.chiOpcode.get === WriteEvictOrEvict && afterIssueE.B ||
       task_s2.bits.chiOpcode.get === Evict
     )
   } else {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -447,7 +447,12 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_release.txnID.get := io.id
     mp_release.homeNID.get := 0.U
     mp_release.dbID.get := 0.U 
-    mp_release.chiOpcode.get := Mux(isWriteBackFull, WriteBackFull, Evict)
+    mp_release.chiOpcode.get := ParallelPriorityMux(Seq(
+      isWriteBackFull       -> WriteBackFull,
+      isWriteEvictFull      -> WriteEvictFull,
+      isWriteEvictOrEvict   -> WriteEvictOrEvict,
+      isEvict /* Default */ -> Evict
+    ))
     mp_release.resp.get := 0.U // DontCare
     mp_release.fwdState.get := 0.U // DontCare
     mp_release.pCrdType.get := 0.U // DontCare // TODO: consider retry of WriteBackFull/Evict

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -183,7 +183,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val mshr_writeCleanFull_s3    = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteCleanFull
   val mshr_writeBackFull_s3     = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteBackFull
   val mshr_writeEvictFull_s3    = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteEvictFull
-  val mshr_writeEvictOrEvict_s3 = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteEvictOrEvict
+  val mshr_writeEvictOrEvict_s3 = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteEvictOrEvict && afterIssueE.B
   val mshr_evict_s3             = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === Evict
   
   val mshr_cbWrData_s3          = mshr_req_s3 && req_s3.toTXDAT && req_s3.chiOpcode.get === CopyBackWrData

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -182,6 +182,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   val mshr_writeCleanFull_s3    = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteCleanFull
   val mshr_writeBackFull_s3     = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteBackFull
+  val mshr_writeEvictFull_s3    = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteEvictFull
+  val mshr_writeEvictOrEvict_s3 = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === WriteEvictOrEvict
   val mshr_evict_s3             = mshr_req_s3 && req_s3.toTXREQ && req_s3.chiOpcode.get === Evict
   
   val mshr_cbWrData_s3          = mshr_req_s3 && req_s3.toTXDAT && req_s3.chiOpcode.get === CopyBackWrData
@@ -419,7 +421,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val wen_c = sinkC_req_s3 && isParamFromT(req_s3.param) && req_s3.opcode(0) && dirResult_s3.hit
   val wen_mshr = req_s3.dsWen && (
     mshr_snpRespX_s3 || mshr_snpRespDataX_s3 ||
-    mshr_writeCleanFull_s3 || mshr_writeBackFull_s3 || mshr_evict_s3 ||
+    mshr_writeCleanFull_s3 || mshr_writeBackFull_s3 || 
+    mshr_writeEvictFull_s3 || mshr_writeEvictOrEvict_s3 || mshr_evict_s3 ||
     mshr_refill_s3 && !need_repl && !retry
   )
   val wen = wen_c || wen_mshr
@@ -583,7 +586,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     mshr_snpRespDataX_s3 || mshr_cbWrData_s3 || mshr_dct_s3,
     req_s3.fromB && !need_mshr_s3 && (doRespDataHitRelease || doRespData && !data_unready_s3) && !txdat_s3_latch.B
   )
-  val isTXREQ_s3 = mshr_req_s3 && (mshr_writeBackFull_s3 || mshr_writeCleanFull_s3 || mshr_evict_s3)
+  val isTXREQ_s3 = mshr_req_s3 && (mshr_writeBackFull_s3 || mshr_writeCleanFull_s3 || 
+     mshr_writeEvictFull_s3 || mshr_writeEvictOrEvict_s3 || mshr_evict_s3)
 
   txreq_s3.valid := task_s3.valid && isTXREQ_s3
   txrsp_s3.valid := task_s3.valid && isTXRSP_s3
@@ -930,6 +934,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   XSPerfAccumulate("mshr_snpRespDataPtl_req", task_s3.valid && mshr_snpRespDataPtl_s3)
   XSPerfAccumulate("mshr_snpRespDataFwded_req", task_s3.valid && mshr_snpRespDataFwded_s3)
   XSPerfAccumulate("mshr_writeBackFull", task_s3.valid && mshr_writeBackFull_s3)
+  XSPerfAccumulate("mshr_writeEvictFull", task_s3.valid && mshr_writeEvictFull_s3)
+  XSPerfAccumulate("mshr_writeEvictOrEvict", task_s3.valid && mshr_writeEvictOrEvict_s3)
   XSPerfAccumulate("mshr_evict_s3", task_s3.valid && mshr_evict_s3)
   
 

--- a/src/main/scala/coupledL2/tl2chi/chi/Message.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Message.scala
@@ -220,6 +220,11 @@ trait HasCHIMsgParameters {
   def ENABLE_ISSUE_Eb = p(CHIIssue) == Issue.Eb
   def ENABLE_ISSUE_B = p(CHIIssue) == Issue.B
 
+  def afterIssueE = p(CHIIssue) match {
+    case Issue.Eb => true
+    case _        => false
+  }
+
   val ISSUE_B_CONFIG = Map(
     "NODEID_WIDTH" -> 7,
     "TXNID_WIDTH" -> 8,

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -85,6 +85,8 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
   def AtomicCompare         = 0x39.U(REQ_OPCODE_WIDTH.W)
   def PrefetchTgt           = 0x3A.U(REQ_OPCODE_WIDTH.W)
 
+  def WriteEvictOrEvict     = 0x42.U(REQ_OPCODE_WIDTH.W)
+
   /**
     * RSP
     */


### PR DESCRIPTION
* For **Issue E.b**, use ```WriteEvictOrEvict``` instead of ```Evict``` on eviction.
* For **Issue B**, we temporarily stay on ```Evict```.