### PR TITLE
fix(BOP): only check `tlbcmd.read`

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -69,9 +69,6 @@ trait HasCoupledL2Parameters {
 
   def mmioBridgeSize = cacheParams.mmioBridgeSize
 
-  // Memory
-  def PmemRanges = cacheParams.PmemRanges
-
   // ECC
   def enableECC = cacheParams.enableTagECC || cacheParams.enableDataECC
   def enableTagECC = cacheParams.enableTagECC

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -97,8 +97,6 @@ case class L2Param(
   ),
 
   hartId: Int = 0,
-  // memory
-  PmemRanges: Seq[(BigInt, BigInt)] = Seq((0x80000000L, 0x80000000000L)),
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
   // Performance analysis

--- a/src/main/scala/coupledL2/prefetch/BestOffsetPrefetch.scala
+++ b/src/main/scala/coupledL2/prefetch/BestOffsetPrefetch.scala
@@ -34,7 +34,7 @@ import chisel3.util._
 import coupledL2.{HasCoupledL2Parameters, L2TlbReq, L2ToL1TlbIO, TlbCmd, Pbmt}
 import coupledL2.utils.ReplacementPolicy
 import scopt.Read
-import freechips.rocketchip.util._
+import freechips.rocketchip.util.SeqToAugmentedSeq
 
 case class BOPParameters(
   virtualTrain: Boolean = true,
@@ -499,38 +499,24 @@ class PrefetchReqBuffer(name: String = "vbop")(implicit p: Parameters) extends B
   val s3_tlb_resp = RegEnable(io.tlb_req.resp.bits, io.tlb_req.resp.valid)
 
   /* entry update */
-  val drop = Wire(Vec(REQ_FILTER_SIZE, Bool()))
-  val drop_excp = Wire(Vec(REQ_FILTER_SIZE, Bool()))
-  val drop_miss = Wire(Vec(REQ_FILTER_SIZE, Bool()))
-  val drop_uncache = Wire(Vec(REQ_FILTER_SIZE, Bool()))
-  val drop_pmp = Wire(Vec(REQ_FILTER_SIZE, Bool()))
-  val drop_range = Wire(Vec(REQ_FILTER_SIZE, Bool()))
+  val exp_drop = Wire(Vec(REQ_FILTER_SIZE, Bool()))
+  val miss_drop = Wire(Vec(REQ_FILTER_SIZE, Bool()))
   val miss_first_replay = Wire(Vec(REQ_FILTER_SIZE, Bool()))
   val pf_fired = Wire(Vec(REQ_FILTER_SIZE, Bool()))
   val tlb_fired = Wire(Vec(REQ_FILTER_SIZE, Bool()))
   for ((e, i) <- entries.zipWithIndex){
     alloc(i) := s1_valid && s1_invalid_oh(i)
     pf_fired(i) := s0_pf_fire_oh(i)
-    
-    val tlb_hit = s3_tlb_fire_oh(i) && s3_tlb_resp_valid && !s3_tlb_resp.miss
-    val tlb_miss = s3_tlb_fire_oh(i) && s3_tlb_resp_valid && s3_tlb_resp.miss
-    miss_first_replay(i) := tlb_miss && !e.replayEn
-    
-    drop_excp(i) := tlb_hit && (
+    exp_drop(i) := s3_tlb_fire_oh(i) && s3_tlb_resp_valid && !s3_tlb_resp.miss && (
       (e.needT && (s3_tlb_resp.excp.head.pf.st || s3_tlb_resp.excp.head.gpf.st || s3_tlb_resp.excp.head.af.st)) ||
       (!e.needT && (s3_tlb_resp.excp.head.pf.ld || s3_tlb_resp.excp.head.gpf.ld || s3_tlb_resp.excp.head.af.ld)) ||
-      io.tlb_req.pmp_resp.ld
+      io.tlb_req.pmp_resp.ld || io.tlb_req.pmp_resp.mmio || Pbmt.isUncache(s3_tlb_resp.pbmt)
     )
-    drop_uncache(i) := tlb_hit && (io.tlb_req.pmp_resp.mmio || Pbmt.isUncache(s3_tlb_resp.pbmt))
-    drop_pmp(i) := tlb_hit && io.tlb_req.pmp_resp.ld
-    drop_range(i) := tlb_hit && !PmemRanges.map(range =>
-      s3_tlb_resp.paddr.head.inRange(range._1.U, range._2.U)
-    ).reduce(_ || _)
-    drop_miss(i) := tlb_miss && e.replayEn
-    drop(i) := drop_excp(i) || drop_uncache(i) || drop_pmp(i) || drop_range(i) || drop_miss(i)
-
-    tlb_fired(i) := tlb_hit && !drop(i)
-
+    val miss = s3_tlb_fire_oh(i) && s3_tlb_resp_valid && s3_tlb_resp.miss
+    tlb_fired(i) := s3_tlb_fire_oh(i) && s3_tlb_resp_valid && !s3_tlb_resp.miss && !exp_drop(i)
+    miss_drop(i) := miss && e.replayEn
+    miss_first_replay(i) := miss && !e.replayEn
+    
     // old data: update replayCnt
     when(valids(i) && e.replayCnt.orR) {
       e.replayCnt := e.replayCnt - 1.U
@@ -538,11 +524,13 @@ class PrefetchReqBuffer(name: String = "vbop")(implicit p: Parameters) extends B
     // recent data: update tlb resp
     when(tlb_fired(i)){
       e.update_paddr(s3_tlb_resp.paddr.head)
-    }.elsewhen(drop(i)) { // miss
+    }.elsewhen(miss_drop(i)) { // miss
       invalid_entry(i)
     }.elsewhen(miss_first_replay(i)){
       e.replayCnt := firstTlbReplayCnt
       e.replayEn := 1.U
+    }.elsewhen(exp_drop(i)){
+      invalid_entry(i)
     }
     // issue data: update pf
     when(pf_fired(i)){
@@ -574,16 +562,20 @@ class PrefetchReqBuffer(name: String = "vbop")(implicit p: Parameters) extends B
 
   XSPerfAccumulate("tlb_req", io.tlb_req.req.valid)
   XSPerfAccumulate("tlb_miss", io.tlb_req.resp.valid && io.tlb_req.resp.bits.miss)
+  XSPerfAccumulate("tlb_excp",
+    s3_tlb_resp_valid && !s3_tlb_resp.miss && (
+      (s3_tlb_resp.excp.head.pf.st || s3_tlb_resp.excp.head.gpf.st || s3_tlb_resp.excp.head.af.st) ||
+      (s3_tlb_resp.excp.head.pf.ld || s3_tlb_resp.excp.head.gpf.ld || s3_tlb_resp.excp.head.af.ld) ||
+      io.tlb_req.pmp_resp.ld || io.tlb_req.pmp_resp.mmio || Pbmt.isUncache(s3_tlb_resp.pbmt)
+  ))
+  XSPerfAccumulate("tlb_excp_pmp_af", s3_tlb_resp_valid && io.tlb_req.pmp_resp.ld)
+  XSPerfAccumulate("tlb_excp_uncache", s3_tlb_resp_valid && (io.tlb_req.pmp_resp.mmio || Pbmt.isUncache(s3_tlb_resp.pbmt)))
   XSPerfAccumulate("entry_alloc", PopCount(alloc))
   XSPerfAccumulate("entry_miss_first_replay", PopCount(miss_first_replay))
+  XSPerfAccumulate("entry_miss_drop", PopCount(miss_drop))
+  XSPerfAccumulate("entry_excp", PopCount(exp_drop))
   XSPerfAccumulate("entry_merge", io.in_req.valid && s0_match)
   XSPerfAccumulate("entry_pf_fire", PopCount(pf_fired))
-  XSPerfAccumulate("entry_total_drop", PopCount(drop))
-  XSPerfAccumulate("entry_drop_excp", PopCount(drop_excp))
-  XSPerfAccumulate("entry_drop_miss", PopCount(drop_miss))
-  XSPerfAccumulate("entry_drop_uncache", PopCount(drop_uncache))
-  XSPerfAccumulate("entry_drop_pmp", PopCount(drop_pmp))
-  XSPerfAccumulate("entry_drop_range", PopCount(drop_range))
   
   /*
   val enTalbe = WireInit(Constantin.createRecord(name+"_isWriteL2BopTable", 1.U))


### PR DESCRIPTION
1. revert `PmemRanges` check, because it will be checked in PMA/PMPChecker
[fix(BOP): add PmemRanges check for vaddr prefetch #310](https://github.com/OpenXiangShan/CoupledL2/pull/310)
3. only check `tlbcmd.read` whether a prefetch request needs `Trunk` or not.

**Why not check `tlbcmd.write` when it needs `Trunk`?** 
1. Firstly, you should get why it needs `Trunk`. When there is a prefetch request based on a store train request, we consider it as if it needs write permission (PMA/P level) and further needs unique permission (cache coherence level). So it needs `Trunk`. 
2. Secondly, why not check `tlbcmd.write`. There should know that the prefetch operation only loads the data to L2Cache, not stores any data. Although we predict that it will be write, it only needs to read at this prefetch operation, so we only need to judge whether it can be read it or not, and leave it to future `store` to judge whether it can be write or not. 
    1. The advantage of only checking `tlbcmd.read` is that for predictive writes that can be read but not writable actually, if the data is read after prefetching, it can save the access time. 
    2. The downside is that if the first one in the future is `store`, this block of data will waste L2Cache.
    4. We believe that the expected benefit of the former is greater, so we adopt the first option.