### PR TITLE
fix(MSHR): TgtID selection for CompAck of WriteEvictOrEvict

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -917,10 +917,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         state.s_cbwrdata.get := isEvict
       }
     }
-    when (io.tasks.txreq.bits.opcode === WriteEvictOrEvict) { // TODO: CHI version control
-      // Mark on WriteEvictOrEvict for TxnID selection of CompAck on Comp
-      req_writeEvictOrEvict := true.B
-    }
   }
   when (io.tasks.txrsp.fire) {
     state.s_compack.get := true.B
@@ -945,6 +941,10 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       // }
       // TODO(retry-immutability): Don't degenerate WriteCleanFull to Evict
       state.s_cbwrdata.get := isEvict
+      when (mp_release.chiOpcode.get === WriteEvictOrEvict) { // TODO: CHI version control
+        // Mark on WriteEvictOrEvict for TxnID selection of CompAck on Comp
+        req_writeEvictOrEvict := true.B
+      }
     }.elsewhen (mp_cbwrdata_valid) {
       state.s_cbwrdata.get := true.B
       meta.state := INVALID

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -941,9 +941,11 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       // }
       // TODO(retry-immutability): Don't degenerate WriteCleanFull to Evict
       state.s_cbwrdata.get := isEvict
-      when (mp_release.chiOpcode.get === WriteEvictOrEvict) { // TODO: CHI version control
-        // Mark on WriteEvictOrEvict for TxnID selection of CompAck on Comp
-        req_writeEvictOrEvict := true.B
+      ifIssueEb {
+        when (mp_release.chiOpcode.get === WriteEvictOrEvict) {
+          // Mark on WriteEvictOrEvict for TxnID selection of CompAck on Comp
+          req_writeEvictOrEvict := true.B
+        }
       }
     }.elsewhen (mp_cbwrdata_valid) {
       state.s_cbwrdata.get := true.B

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -81,6 +81,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   initState.elements.foreach(_._2 := true.B)
   val state     = RegInit(new FSMState(), initState)
 
+  val req_writeEvictOrEvict = RegInit(false.B)
+
   assert(!(req_valid && dirResult.hit && !isT(meta.state) && meta.dirty),
     "directory valid read with dirty under non-T state")
 
@@ -145,6 +147,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
     retryTimes := 0.U
     backoffTimer := 0.U
+
+    req_writeEvictOrEvict := false.B
   }
 
   /* ======== Enchantment ======== */
@@ -307,7 +311,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     val txrsp_task = {
       val orsp = io.tasks.txrsp.bits
       orsp := 0.U.asTypeOf(io.tasks.txrsp.bits.cloneType)
-      orsp.tgtID := Mux(req_acquirePerm, srcid, homenid)
+      orsp.tgtID := Mux(req_acquirePerm || req_writeEvictOrEvict, srcid, homenid)
       orsp.srcID := 0.U
       orsp.txnID := dbid
       orsp.dbID := 0.U
@@ -912,6 +916,10 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         // TODO(retry-immutability): Don't degenerate WriteCleanFull to Evict
         state.s_cbwrdata.get := isEvict
       }
+    }
+    when (io.tasks.txreq.bits.opcode === WriteEvictOrEvict) { // TODO: CHI version control
+      // Mark on WriteEvictOrEvict for TxnID selection of CompAck on Comp
+      req_writeEvictOrEvict := true.B
     }
   }
   when (io.tasks.txrsp.fire) {


### PR DESCRIPTION
The **```TgtID```** of ```CompAck``` for ```WriteEvictOrEvict``` should be propagated from **```SrcID```** of ```Comp```.