### PR TITLE
feat(TopDown): add l2Miss IO for Top-Down

### DIFF
--- a/src/main/scala/coupledL2/BaseSlice.scala
+++ b/src/main/scala/coupledL2/BaseSlice.scala
@@ -36,6 +36,7 @@ abstract class BaseSliceIO[T_OUT <: BaseOuterBundle](implicit p: Parameters) ext
   val dirResult = topDownOpt.map(_ => ValidIO(new DirResult))
   val latePF = topDownOpt.map(_ => Output(Bool()))
   val error = DecoupledIO(new L2CacheErrorInfo())
+  val l2Miss = Output(Bool())
 }
 
 abstract class BaseSlice[T_OUT <: BaseOuterBundle](implicit p: Parameters) extends L2Module with HasPerfEvents {

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -322,6 +322,7 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
         val robHeadPaddr = Flipped(Valid(UInt(36.W)))
         val l2MissMatch = Output(Bool())
       }
+      val l2Miss = Output(Bool())
       val error = Output(new L2CacheErrorInfo()(l2ECCParams))
     })
 
@@ -563,6 +564,8 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
         t.io.debugTopDown <> io.debugTopDown
       case None => io.debugTopDown.l2MissMatch := false.B
     }
+
+    io.l2Miss := RegNext(slices.map(_.io.l2Miss).reduce(_ || _))
 
     // ==================== XSPerf Counters ====================
     val grant_data_fire = slices.map { slice => 

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -83,6 +83,9 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
 
     /* to Slice Top for pCrd info.*/
     val pCrd = Vec(mshrsAll, new PCrdQueryBundle)
+
+    /* for TopDown */
+    val l2Miss = Output(Bool())
   })
 
   /*MSHR allocation pointer gen -> to Mainpipe*/
@@ -106,6 +109,12 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
   val mshrSelector = Module(new MSHRSelector())
   val selectedMSHROH = mshrSelector.io.out.bits
 
+  io.l2Miss := Cat(mshrs.map { m =>
+    m.io.status.valid && m.io.status.bits.channel(0) && (
+      m.io.status.bits.reqSource === MemReqSource.CPULoadData.id.U ||
+      m.io.status.bits.reqSource === MemReqSource.CPUStoreData.id.U
+    )
+  }).orR
   mshrSelector.io.idle := mshrs.map(m => !m.io.status.valid)
   io.toMainPipe.mshr_alloc_ptr := OHToUInt(selectedMSHROH)
 

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -186,6 +186,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
       io.latePF.get := reqBuf.io.hasLatePF
     }
   )
+  io.l2Miss := mshrCtl.io.l2Miss
 
   /* Connect upwards channels */
   val inBuf = cacheParams.innerBuf

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -182,6 +182,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
       io.latePF.get          := a_reqBuf.io.hasLatePF
     }
   )
+  io.l2Miss := mshrCtl.io.l2Miss
 
   if (cacheParams.enablePerf) {
     val a_begin_times = RegInit(VecInit(Seq.fill(sourceIdAll)(0.U(64.W))))


### PR DESCRIPTION
This PR adds the signal of l2Miss and excludes all prefetch.
Whenever there is a L2 miss, the l2miss signal is pulled up.