### PR TITLE
timing(Slice, BOP): avoid timing path from SRAM to ICG

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -195,8 +195,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   sinkC.io.c <> inBuf.c(io.in.c)
   io.in.d <> inBuf.d(grantBuf.io.d)
   grantBuf.io.e <> inBuf.e(io.in.e)
-  io.error.valid := mainPipe.io.error.valid
-  io.error.bits := mainPipe.io.error.bits
+  io.error.valid := RegNext(mainPipe.io.error.valid, false.B)
+  io.error.bits := RegNext(mainPipe.io.error.bits)
 
   /* Connect downwards channels */
   io.out.tx.req <> txreq.io.out

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -161,8 +161,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   sinkC.io.c <> inBuf.c(io.in.c)
   io.in.d <> inBuf.d(grantBuf.io.d)
   grantBuf.io.e <> inBuf.e(io.in.e)
-  io.error.valid := mainPipe.io.error.valid
-  io.error.bits := mainPipe.io.error.bits
+  io.error.valid := RegNext(mainPipe.io.error.valid, false.B)
+  io.error.bits := RegNext(mainPipe.io.error.bits)
 
   /* connect downward channels */
   io.out.a <> outBuf.a(mshrCtl.io.sourceA)


### PR DESCRIPTION
This commit removes critical timing paths from SRAM to ICG, mainly including:

- DataStorage SRAM read result -> error -> regs in BusErrorUnit
- RecentRequestTable SRAM result -> rrTable hit or not -> update ScoreTable