### PR TITLE
feat(MSHR, MainPipe): support SnpQuery for Issue E.b

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -287,7 +287,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     snpToB -> SC,
     isSnpOnceX(req_chiOpcode) ->
       Mux(req.snpHitRelease, I, Mux(probeDirty || meta.dirty, UD, metaChi)),
-    isSnpStashX(req_chiOpcode) ->
+    (isSnpStashX(req_chiOpcode) || isSnpQuery(req_chiOpcode)) ->
       Mux(probeDirty || meta.dirty, UD, metaChi),
     isSnpCleanShared(req_chiOpcode) -> 
       Mux(isT(meta.state), UC, metaChi)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -222,10 +222,13 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   dontTouch(doRespData_retToSrc_nonFwd)
 
   // *NOTICE: SnpUniqueStash was included in condition 'doRespData_retToSrc_nonFwd', while
-  //          the 'retToSrc' of SnpUniqueStash must be bound to 0, and whether responding 
+  //          the 'retToSrc' of SnpUniqueStash must be bound to 0, and whether responding
   //          SnpRespData or SnpResp was not determined by 'retToSrc'.
+  //          the 'retToSrc' of SnpQuery must be bound to 0
   assert(!(req_valid && req_chiOpcode === SnpUniqueStash && req.retToSrc.get),
     "specification failure: received SnpUniqueStash with RetToSrc = 1")
+  assert(!(req_valid && isSnpQuery(req_chiOpcode) && req.retToSrc.get),
+    "specification failure: received SnpQuery with RetToSrc = 1")
 
   /**
     * About which snoop should echo SnpResp[Data]Fwded instead of SnpResp[Data]:

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -287,6 +287,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val retToSrc = req_s3.retToSrc.getOrElse(false.B)
   val neverRespData = isSnpMakeInvalidX(req_s3.chiOpcode.get) ||
     isSnpStashX(req_s3.chiOpcode.get) ||
+    isSnpQuery(req_s3.chiOpcode.get) ||
     req_s3.chiOpcode.get === SnpOnceFwd ||
     req_s3.chiOpcode.get === SnpUniqueFwd
   val shouldRespData_dirty = dirResult_s3.hit && (meta_s3.state === TIP || meta_s3.state === TRUNK) && meta_s3.dirty
@@ -309,13 +310,14 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   // Resp[2: 0] = {PassDirty, CacheState[1: 0]}
   val respCacheState = WireInit(I)
   val respPassDirty = dirResult_s3.hit && meta_s3.state === TIP && meta_s3.dirty &&
-    !(neverRespData || req_s3.chiOpcode.get === SnpOnce) && !isSnpStashX(req_s3.chiOpcode.get)
+    !(neverRespData || req_s3.chiOpcode.get === SnpOnce) &&
+    !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))
 
   when (dirResult_s3.hit) {
     when (isSnpToB(req_s3.chiOpcode.get)) {
       respCacheState := SC
     }
-    when (isSnpOnceX(req_s3.chiOpcode.get) || isSnpStashX(req_s3.chiOpcode.get)) {
+    when (isSnpOnceX(req_s3.chiOpcode.get) || isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
         meta_s3.state === BRANCH,
         SC,
@@ -328,8 +330,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   }
 
   when (req_s3.snpHitRelease) {
-    // *NOTICE: On Stash, the cache state must maintain unchanged on nested WriteBack
-    when (isSnpStashX(req_s3.chiOpcode.get)) {
+    // *NOTICE: On Stash and Query, the cache state must maintain unchanged on nested WriteBack
+    when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
         req_s3.snpHitReleaseState === BRANCH,
         SC,
@@ -385,7 +387,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       Cat(true.B, true.B)   -> SnpRespDataFwded
     )))
     sink_resp_s3.bits.resp.foreach(_ := Mux(
-      req_s3.snpHitRelease && !isSnpStashX(req_s3.chiOpcode.get),
+      req_s3.snpHitRelease && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
       setPD(I, req_s3.snpHitReleaseWithData && !isSnpMakeInvalidX(req_s3.chiOpcode.get)),
       setPD(respCacheState, respPassDirty && (doRespData || doRespDataHitRelease))
     ))
@@ -472,7 +474,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   /* ======== Write Directory ======== */
   val metaW_valid_s3_a = sinkA_req_s3 && !need_mshr_s3_a && !req_get_s3 && !req_prefetch_s3 && !cmo_cbo_s3 // get & prefetch that hit will not write meta
   val metaW_valid_s3_b = sinkB_req_s3 && !need_mshr_s3_b && dirResult_s3.hit &&
-    !isSnpOnceX(req_s3.chiOpcode.get) && !isSnpStashX(req_s3.chiOpcode.get) && (
+    !isSnpOnceX(req_s3.chiOpcode.get) && !isSnpStashX(req_s3.chiOpcode.get) && !isSnpQuery(req_s3.chiOpcode.get) && (
       meta_s3.state === TIP || meta_s3.state === BRANCH && isSnpToN(req_s3.chiOpcode.get)
     )
   val metaW_valid_s3_c = sinkC_req_s3 && dirResult_s3.hit
@@ -617,11 +619,11 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     * 1. snoop nests a copy-back request
     * 2. snoop nests a Read/MakeUnique request
     * 
-    * *NOTICE: Never allow 'b_inv_dirty' on SnpStash* and other future snoops that would
+    * *NOTICE: Never allow 'b_inv_dirty' on SnpStash*, SnpQuery and other future snoops that would
     *          leave cache line state untouched.
     */
   io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitRelease &&
-    !isSnpStashX(req_s3.chiOpcode.get)
+    !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))
   io.nestedwb.b_toB.foreach(_ :=
     task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && source_req_s3.meta.state === BRANCH
   )

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -155,7 +155,7 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
   }
 
   def isSnpQuery(opcode: UInt): Bool = {
-    opcode === SnpQuery
+    onIssueEbOrElse(opcode === SnpQuery, false.B)
   }
 
   def isSnpOnceX(opcode: UInt): Bool = {

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -134,6 +134,7 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
   def SnpStashShared        = 0x0C.U(SNP_OPCODE_WIDTH.W)
   def SnpDVMOp              = 0x0D.U(SNP_OPCODE_WIDTH.W)
 
+  def SnpQuery              = Eb_OPCODE(0x10.U, SNP_OPCODE_WIDTH)
   def SnpSharedFwd          = 0x11.U(SNP_OPCODE_WIDTH.W)
   def SnpCleanFwd           = 0x12.U(SNP_OPCODE_WIDTH.W)
   def SnpOnceFwd            = 0x13.U(SNP_OPCODE_WIDTH.W)
@@ -153,6 +154,9 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
     opcode >= SnpSharedFwd
   }
 
+  def isSnpQuery(opcode: UInt): Bool = {
+    opcode === SnpQuery
+  }
 
   def isSnpOnceX(opcode: UInt): Bool = {
     opcode === SnpOnce || opcode === SnpOnceFwd


### PR DESCRIPTION
This commit supports `SnpQuery`, which is newly supported in Issue E, in CoupledL2.

Brief cache state transitions of `SnpQuery` are as followed:
| Opcode | Initial State | Final State | RetToSrc | Snoop response |
| :---: | :---: | :---: | :---: | :---: |
| SnpQuery| I | I | X | SnpResp_I |
| | UC | UC | 0 | SnpResp_UC |
| | UD | UD | 0 | SnpResp_UD |
| | SC | SC | 0 | SnpResp_SC |

Besides, in Snoopee(L2),  `SnpQuery` must obey following rules:
* Snoop response must not be returned with data
* The state of Snoopee's cache line must not be changed
* `SnpQuery` is only supported in Issue E.b