### PR TITLE
fix(MSHR): always update meta on ProbeAck TtoB under ```cbo.clean```

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -271,6 +271,7 @@ class FSMState(implicit p: Parameters) extends L2Bundle {
   // val s_triggerprefetch = prefetchOpt.map(_ => Bool())
   val s_retry = Bool()    // need retry when conflict
   val s_cmoresp = Bool()  // resp upwards for finishing CMO transactions
+  val s_cmometaw = Bool() // meta write compensation for CMO transactions
 
   // wait
   val w_rprobeackfirst = Bool()

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -877,7 +877,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cmometaw.meta := meta
     mp_cmometaw.meta.dirty := false.B
     mp_cmometaw.meta.state := TIP // write TIP for compensation of ProbeAck TtoB by cbo.clean
-    mp_cmometaw.meta.clients := Fill(clientBits, false.B)
     mp_cmometaw.metaWen := true.B
     mp_cmometaw.tagWen := false.B
     mp_cmometaw.dsWen := false.B
@@ -1069,7 +1068,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
           state.w_releaseack := false.B
         }.otherwise {
           // meta write compensation on ProbeAck TtoB
-          state.s_cmometaw := true.B
+          state.s_cmometaw := false.B
         }
       }
     }


### PR DESCRIPTION
* On **```cbo.clean```**, the ```WriteCleanFull``` was determined to be sent only when L1 returned dirty data or L2 contained dirty data.
* Directory meta update was done only by ```mp_release``` on ```WriteCleanFull``` before for CMO operations.
* When L2 contained clean record and L1 returned clean (```ProbeAck TtoB```), ```WriteCleanFull``` was unnecessary. While, the cache line state was still needed to be updated from ```TRUNK``` to ```TIP``` in L2. So ```mp_cmometaw``` was introduced for cache line state update compensation for ```ProbeAck TtoB```.