### PR TITLE
fix(MSHR): consider WriteEvict* as nested write back

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1277,7 +1277,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.w_releaseack := state.w_releaseack
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast
-  io.msInfo.bits.replaceData := isT(meta.state) && meta.dirty || probeDirty
+  io.msInfo.bits.replaceData := isT(meta.state) && meta.dirty || probeDirty || isWriteEvictFull || isWriteEvictOrEvict
   io.msInfo.bits.releaseToB := releaseToB
   io.msInfo.bits.channel := req.channel
 

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1280,7 +1280,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.w_releaseack := state.w_releaseack
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast
-  io.msInfo.bits.replaceData := isT(meta.state) && meta.dirty || probeDirty || isWriteEvictFull || isWriteEvictOrEvict
+  io.msInfo.bits.replaceData := isT(meta.state) && meta.dirty || probeDirty || // including WriteCleanFull
+                                isWriteEvictFull || isWriteEvictOrEvict
   io.msInfo.bits.releaseToB := releaseToB
   io.msInfo.bits.channel := req.channel
 

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -292,9 +292,11 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     snpToN -> I,
     snpToB -> SC,
     isSnpOnceX(req_chiOpcode) ->
-      Mux(req.snpHitRelease,
+      Mux(
+        req.snpHitRelease,
         I, // also see 'nestedwb.b_inv_dirty' in MainPipe
-        Mux(probeDirty || meta.dirty, UD, metaChi)),
+        Mux(probeDirty || meta.dirty, UD, metaChi)
+      ),
     (isSnpStashX(req_chiOpcode) || isSnpQuery(req_chiOpcode)) ->
       Mux(probeDirty || meta.dirty, UD, metaChi),
     isSnpCleanShared(req_chiOpcode) -> 

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -176,7 +176,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val cmo_cbo = req_cboClean || req_cboFlush || req_cboInval
 
   val hitDirty = dirResult.hit && meta.dirty || probeDirty
-  val hitWriteBack = req.snpHitRelease && req.snpHitReleaseWithData
+  val hitWriteBack = req.snpHitRelease && req.snpHitReleaseWithData && req.snpHitReleaseDirty
+  val hitWriteEvict = req.snpHitRelease && req.snpHitReleaseWithData && !req.snpHitReleaseDirty
+  val hitWriteX = hitWriteBack || hitWriteEvict
   val hitDirtyOrWriteBack = hitDirty || hitWriteBack
 
   val releaseToB = req_cboClean
@@ -207,13 +209,12 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val doRespData_retToSrc_nonFwd = req.retToSrc.get && (
     dirResult.hit && meta.state === BRANCH &&
       (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode) || isSnpOnce(req_chiOpcode)) ||
-    hitWriteBack && req.snpHitReleaseState === BRANCH &&
+    hitWriteEvict &&
        isSnpOnce(req_chiOpcode))
   // doRespData_once includes SnpOnceFwd(nested) UD -> I and SnpOnce UC -> UC/I(non-nested/nested)
-  val doRespData_once = hitWriteBack && req.snpHitReleaseDirty &&
+  val doRespData_once = hitWriteBack &&
       isSnpOnceFwd(req_chiOpcode) ||
-    (dirResult.hit && !meta.dirty && meta.state =/= BRANCH ||
-      hitWriteBack && !req.snpHitReleaseDirty && req.snpHitReleaseState =/= BRANCH) &&
+    (dirResult.hit && !meta.dirty && meta.state =/= BRANCH || hitWriteEvict) &&
       isSnpOnce(req_chiOpcode)
   val doRespData = doRespData_dirty || doRespData_retToSrc_fwd || doRespData_retToSrc_nonFwd || doRespData_once
 
@@ -235,7 +236,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     * 1. When the snoop opcode is Snp*Fwd and the snooped block is valid.
     */
   val doFwd = isSnpXFwd(req_chiOpcode) && dirResult.hit
-  val doFwdHitRelease = isSnpXFwd(req_chiOpcode) && hitWriteBack
+  val doFwdHitRelease = isSnpXFwd(req_chiOpcode) && hitWriteX
 
   val gotUD = meta.dirty //TC/TTC -> UD
   val promoteT_normal =  dirResult.hit && meta_no_client && meta.state === TIP
@@ -291,7 +292,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     snpToN -> I,
     snpToB -> SC,
     isSnpOnceX(req_chiOpcode) ->
-      Mux(req.snpHitRelease, I, Mux(probeDirty || meta.dirty, UD, metaChi)),
+      Mux(req.snpHitRelease,
+        I, // also see 'nestedwb.b_inv_dirty' in MainPipe
+        Mux(probeDirty || meta.dirty, UD, metaChi)),
     (isSnpStashX(req_chiOpcode) || isSnpQuery(req_chiOpcode)) ->
       Mux(probeDirty || meta.dirty, UD, metaChi),
     isSnpCleanShared(req_chiOpcode) -> 
@@ -303,7 +306,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     req_chiOpcode === SnpUniqueStash ||
     req_chiOpcode === SnpCleanShared ||
     req_chiOpcode === SnpCleanInvalid ||
-    isSnpOnceX(req_chiOpcode) && hitWriteBack && req.snpHitReleaseDirty
+    isSnpOnceX(req_chiOpcode) && hitWriteBack
   )
   val fwdCacheState = Mux(
     isSnpToBFwd(req_chiOpcode),

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -622,6 +622,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     * 
     * *NOTICE: Never allow 'b_inv_dirty' on SnpStash*, SnpQuery and other future snoops that would
     *          leave cache line state untouched.
+    * 
+    * *TODO: A SnpOnce* nesting WriteCleanFull would result in SnpResp*_I_PD, which was simple to
+    *        implement but could be further optimized.
     */
   io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitRelease &&
     !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -389,7 +389,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     )))
     sink_resp_s3.bits.resp.foreach(_ := Mux(
       req_s3.snpHitRelease && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
-      setPD(I, req_s3.snpHitReleaseWithData && !isSnpMakeInvalidX(req_s3.chiOpcode.get)),
+      setPD(I, req_s3.snpHitReleaseWithData && req_s3.snpHitReleaseDirty && !isSnpMakeInvalidX(req_s3.chiOpcode.get)),
       setPD(respCacheState, respPassDirty && (doRespData || doRespDataHitRelease))
     ))
     sink_resp_s3.bits.fwdState.foreach(_ := setPD(fwdCacheState, fwdPassDirty))

--- a/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Opcode.scala
@@ -151,7 +151,11 @@ trait HasCHIOpcodes extends HasCHIMsgParameters {
   }
 
   def isSnpXFwd(opcode: UInt): Bool = {
-    opcode >= SnpSharedFwd
+    opcode === SnpSharedFwd || 
+    opcode === SnpCleanFwd || 
+    opcode === SnpOnceFwd ||
+    opcode === SnpNotSharedDirtyFwd ||
+    opcode === SnpUniqueFwd
   }
 
   def isSnpQuery(opcode: UInt): Bool = {


### PR DESCRIPTION
* For **```WriteEvictFull```** and **```WriteEvictOrEvict```**, there is no **silent eviction** path as **```Evict```**. So the initial state of **```WriteEvictFull```** and **```WriteEvictOrEvict```** was never allowed to be ```I```, and the cache state transition must no be done before any WriteData response. Hence, **```WriteEvictFull```** and **```WriteEvictOrEvict```** must be nested by snoops just like **```WriteBackFull```**.
* Distinguishing **```WriteEvictFull```** and **```WriteEvictOrEvict```** from **```WriteBackFull```** for correcting ```PassDirty``` field implementation of nested snoops.