### PR TITLE
fix(TXDAT, RXDAT, MMIOBridge): DataCheck uses odd parity, and support NC

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -160,11 +160,11 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
         case 1 => (0 until DATACHECK_WIDTH).map(i =>
-          rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ true.B).reduce(_ | _)
+          rxdat.bits.dataCheck(i) ^ rdata(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
         case 2 =>
           val code = new SECDEDCode
           (0 until DATACHECK_WIDTH).map(i =>
-            code.decode(Cat(rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)))).error).reduce(_ | _)
+            code.decode(Cat(rxdat.bits.dataCheck(i) ^ rdata(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
         case _ => false.B
       }
     } else {
@@ -285,10 +285,10 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   val txdata = txdat.bits.data
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
-      case 1 => Cat((0 until DATACHECK_WIDTH).map(i => txdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR.asUInt ^ 1.U))
+      case 1 => VecInit((0 until DATACHECK_WIDTH).map(i => txdata(8 * (i + 1) - 1, 8 * i).xorR ^ true.B)).asUInt
       case 2 =>
         val code = new SECDEDCode
-        Cat((0 until DATACHECK_WIDTH).map(i => code.encode(txdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1))).asUInt))
+        VecInit((0 until DATACHECK_WIDTH).map(i => code.encode(txdata(8 * (i + 1) - 1, 8 * i)))).asUInt
       case _ => 0.U(DATACHECK_WIDTH.W)
     }
   } else {

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -160,7 +160,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
         case 1 => (0 until DATACHECK_WIDTH).map(i =>
-          rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR).reduce(_ & _)
+          rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ 1.U).reduce(_ | _)
         case 2 =>
           val code = new SECDEDCode
           (0 until DATACHECK_WIDTH).map(i =>

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -160,7 +160,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
         case 1 => (0 until DATACHECK_WIDTH).map(i =>
-          rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ 1.U).reduce(_ | _)
+          rxdat.bits.dataCheck(i) ^ rdata(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ true.B).reduce(_ | _)
         case 2 =>
           val code = new SECDEDCode
           (0 until DATACHECK_WIDTH).map(i =>

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,7 +41,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR).reduce(_ & _)
+        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ 1.U).reduce(_ | _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,7 +41,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR).reduce(_ | _)
+        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR).reduce(_ & _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,11 +41,11 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ true.B).reduce(_ | _)
+        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>
-          code.decode(Cat(io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)))).error).reduce(_ | _)
+          code.decode(Cat(io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
       case _ => false.B
     }
   } else {

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,11 +41,11 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR).reduce(_ & _)
+        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR).reduce(_ & _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>
-          code.decode(Cat(io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
+          code.decode(Cat(io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)))).error).reduce(_ | _)
       case _ => false.B
     }
   } else {

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,7 +41,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ 1.U).reduce(_ | _)
+        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR ^ true.B).reduce(_ | _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -133,10 +133,10 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
-        case 1 => Cat((0 until DATACHECK_WIDTH).map(i => beat(8 * (i + 1) - 1, 8 * i).xorR.asUInt ^ 1.U))
+        case 1 => Cat((0 until DATACHECK_WIDTH).map(i => beat(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR.asUInt ^ 1.U))
         case 2 =>
           val code = new SECDEDCode
-          Cat((0 until DATACHECK_WIDTH).map(i => code.encode(beat(8 * (i + 1) - 1, 8 * i)).asUInt))
+          Cat((0 until DATACHECK_WIDTH).map(i => code.encode(beat(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1))).asUInt))
         case _ => 0.U(DATACHECK_WIDTH.W)
       }
     } else {

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -133,10 +133,10 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
-        case 1 => Cat((0 until DATACHECK_WIDTH).map(i => beat(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1)).xorR.asUInt ^ 1.U))
+        case 1 => VecInit((0 until DATACHECK_WIDTH).map(i => beat(8 * (i + 1) - 1, 8 * i).xorR ^ true.B)).asUInt
         case 2 =>
           val code = new SECDEDCode
-          Cat((0 until DATACHECK_WIDTH).map(i => code.encode(beat(8 * (DATACHECK_WIDTH - i) - 1, 8 * (DATACHECK_WIDTH - i - 1))).asUInt))
+          VecInit((0 until DATACHECK_WIDTH).map(i => code.encode(beat(8 * (i + 1) - 1, 8 * i)))).asUInt
         case _ => 0.U(DATACHECK_WIDTH.W)
       }
     } else {

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -133,7 +133,7 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
-        case 1 => Cat((0 until DATACHECK_WIDTH).map(i => beat(8 * (i + 1) - 1, 8 * i).xorR.asUInt))
+        case 1 => Cat((0 until DATACHECK_WIDTH).map(i => beat(8 * (i + 1) - 1, 8 * i).xorR.asUInt ^ 1.U))
         case 2 =>
           val code = new SECDEDCode
           Cat((0 until DATACHECK_WIDTH).map(i => code.encode(beat(8 * (i + 1) - 1, 8 * i)).asUInt))


### PR DESCRIPTION
This pr fixes bugs concerning `DataCheck`:

* According to the CHI manual, `DataCheck` should use odd parity. Fixed the issue where even parity was incorrectly used in `TXDAT` and `RXDAT`: the parity bit should be obtained by XOR all bits of the data and then XOR the result with 1.
* Should use `VecInit` instead of `Cat` to avoid reverse sequence.
* In `MMIOBridge`, `DataCheck` operations, which are the same as those in `TXDAT` & `RXDAT`, are added for `NC`.