### PR TITLE
fix(TXDAT): fix incorrect assignment of CCID

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -129,7 +129,6 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     // width parameters and width check
     require(beat.getWidth == dat.data.getWidth)
     val beatOffsetWidth = log2Up(beatBytes)
-    val chunkOffsetWidth = log2Up(16) // DataID is assigned with the granularity of a 16-byte chunk
 
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
@@ -153,13 +152,14 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     dat.homeNID := task.homeNID.get
     dat.dbID := task.dbID.get
     dat.opcode := task.chiOpcode.get
-    dat.ccID := 0.U // TODO: consider critical chunk id
+    // The CCID field must match the value of Addr[5:4] of the original request.
+    dat.ccID := task.off >> ChunkOffsetWidth
     // The DataID field value must be set to Addr[5:4] because the DataID field represents Addr[5:4] of the lowest
     // addressed byte within the packet.
     // dat.dataID := ParallelPriorityMux(beatsOH.asBools.zipWithIndex.map(x => (x._1, (x._2 << beatOffsetWidth).U(5, 4))))
     dat.dataID := ParallelPriorityMux(
       beatsOH,
-      List.tabulate(beatSize)(i => (i << (beatOffsetWidth - chunkOffsetWidth)).U)
+      List.tabulate(beatSize)(i => (i << (beatOffsetWidth - ChunkOffsetWidth)).U)
     )
     dat.be := be
     dat.data := deassertData(beat, be)

--- a/src/main/scala/coupledL2/tl2chi/chi/Message.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Message.scala
@@ -332,6 +332,10 @@ trait HasCHIMsgParameters {
   def TAG_WIDTH = DATA_WIDTH / 32
   def TAG_UPDATE_WIDTH = DATA_WIDTH / 128
 
+  // DataID is assigned with the granularity of a 16-byte chunk
+  def ChunkBytes = 16
+  def ChunkOffsetWidth = log2Up(ChunkBytes)
+
   // User defined
   /*
   * Currently don't care about *::RSVDC, and the width is tied to 4.


### PR DESCRIPTION
According to CHI spec, the CCID field must match the value of Addr[5:4] of the original request, and transactions which contain multiple data packets must use the same CCID value for all data packets.