### PR TITLE
fix(CoupledL2): initialize DataCheck legally

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -82,15 +82,6 @@ trait HasCoupledL2Parameters {
   def encDataBankBits = cacheParams.dataCode.width(blockBytes * 2)
   def eccDataBankBits = encDataBits - blockBytes * 2
 
-  // DataCheck
-  def dataCheckMethod : Int = cacheParams.dataCheck.getOrElse("none").toLowerCase match {
-    case "none" => 0
-    case "oddparity" => 1
-    case "secded" => 2
-    case _ => 0
-  }
-  def enableDataCheck = enableCHI && dataCheckMethod != 0
-
   // Prefetch
   def prefetchers = cacheParams.prefetch
   def prefetchOpt = if(prefetchers.nonEmpty) Some(true) else None

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -160,11 +160,11 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
         case 1 => (0 until DATACHECK_WIDTH).map(i =>
-          rxdat.bits.dataCheck(i) ^ rdata(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
+          rxdat.bits.dataCheck.get(i) ^ rdata(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
         case 2 =>
           val code = new SECDEDCode
           (0 until DATACHECK_WIDTH).map(i =>
-            code.decode(Cat(rxdat.bits.dataCheck(i) ^ rdata(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
+            code.decode(Cat(rxdat.bits.dataCheck.get(i) ^ rdata(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
         case _ => false.B
       }
     } else {
@@ -292,9 +292,13 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       case _ => 0.U(DATACHECK_WIDTH.W)
     }
   } else {
-    0.U(DATACHECK_WIDTH.W)
+    DontCare
   }
-  txdat.bits.dataCheck := dataCheck
+  txdat.bits.dataCheck match {
+    case Some(x) =>
+      x := dataCheck
+    case None =>
+  }
 
   rxrsp.ready := (!w_comp || !w_dbidresp || !w_readreceipt.getOrElse(true.B)) && s_txreq
   rxdat.ready := !w_compdata && s_txreq

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -41,11 +41,11 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val dataCheck = if (enableDataCheck) {
     dataCheckMethod match {
       case 1 => (0 until DATACHECK_WIDTH).map(i =>
-        io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
+        io.out.bits.dataCheck.get(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
       case 2 =>
         val code = new SECDEDCode
         (0 until DATACHECK_WIDTH).map(i =>
-          code.decode(Cat(io.out.bits.dataCheck(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
+          code.decode(Cat(io.out.bits.dataCheck.get(i) ^ io.out.bits.data(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
       case _ => false.B
     }
   } else {

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -139,7 +139,7 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         case _ => 0.U(DATACHECK_WIDTH.W)
       }
     } else {
-      0.U(DATACHECK_WIDTH.W)
+      DontCare
     }
 
     val deassertBE = task.chiOpcode.get === CopyBackWrData && task.resp.get === I ||
@@ -167,7 +167,11 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     // dat.fwdState := task.fwdState.get
     dat.setFwdState(task.fwdState.get)
     dat.traceTag := task.traceTag.get
-    dat.dataCheck := dataCheck
+    dat.dataCheck match {
+      case Some(x) =>
+        x := dataCheck
+      case None =>
+    }
     dat.poision := Fill(POISON_WIDTH, task.corrupt)
 
     dat

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -199,6 +199,7 @@ object TestTopCHIHelper {
 
         // prefetch
         prefetch            = Seq(BOPParameters()),
+        dataCheck           = Some("oddparity"),
 
         // using external RN-F SAM
         sam                 = Seq(AddressSet.everything -> 0)


### PR DESCRIPTION
According to CHI manual, `DataCheck` field should not be present in DAT packet when it's not specified or set to False.

In this pr, 
* In `TestTop`(CHI version), Data Check option is set to `oddparity` as default.
* `enableDataCheck` parameter is moved from `HasCoupledL2Parameters` to `HasCHIMsgParameters`.
* `DataCheck` field in `TXDAT` is defined as Option UInt variable.

When Data Check is enabled, TXDAT/RXDAT/MMIOBridge chooses `oddparity` or `SECDED` accordingly;
otherwise, `DataCheck` filed is `None` in DAT packet.

