### PR TITLE
feat(DataStorage): split ClockGate for each of the Splitted SRAMs

### DIFF
--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -19,7 +19,7 @@ package coupledL2
 
 import chisel3._
 import chisel3.util._
-import coupledL2.utils.{HoldUnless, SplittedSRAM}
+import coupledL2.utils.{HoldUnless, GatedSplittedSRAM}
 import utility.{ClockGate, SRAMTemplate}
 import org.chipsalliance.cde.config.Parameters
 
@@ -74,7 +74,7 @@ class DataStorage(implicit p: Parameters) extends L2Module {
   })
 
   // read data is set MultiCycle Path 2
-  val array = Module(new SplittedSRAM(
+  val array = Module(new GatedSplittedSRAM(
     gen = new DSECCBankBlock,
     set = blocks,
     way = 1,
@@ -82,9 +82,7 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     singlePort = true,
     readMCP2 = true
   ))
-
-  val masked_clock = ClockGate(false.B, io.en, clock)
-  array.clock := masked_clock
+  array.io_en := io.en
 
   val arrayIdx = Cat(io.req.bits.way, io.req.bits.set)
   val wen = io.req.valid && io.req.bits.wen

--- a/src/main/scala/coupledL2/utils/GatedSplittedSRAM.scala
+++ b/src/main/scala/coupledL2/utils/GatedSplittedSRAM.scala
@@ -1,0 +1,37 @@
+package coupledL2.utils
+
+import chisel3._
+import chisel3.util._
+import utility.ClockGate
+
+// SplittedSRAM with clockGate to each of the small splitted srams
+// - this is a requirement from DFT, cause mbist needs to access each sram separately
+//   and it will add addtional logic using ClockGate
+// - so ClockGate need also be splitted
+
+class GatedSplittedSRAM[T <: Data]
+(
+  gen: T, set: Int, way: Int,
+  setSplit: Int = 1, waySplit: Int = 1, dataSplit: Int = 1,
+  shouldReset: Boolean = false, holdRead: Boolean = false,
+  singlePort: Boolean = true, bypassWrite: Boolean = false,
+  clkDivBy2: Boolean = false, readMCP2: Boolean = true
+) extends SplittedSRAM[T](
+  gen, set, way,
+  setSplit, waySplit, dataSplit,
+  shouldReset, holdRead, singlePort, bypassWrite, clkDivBy2, readMCP2
+) {
+  // en is the actual r/w valid (last for one cycle)
+  // en is used to generate gated_clock for each SRAM
+  val io_en = IO(Input(Bool()))
+
+  // Create a ClockGate module for each element in the array
+  array.map(_.map(_.map(_.clock := ClockGate(false.B, io_en, clock))))
+
+  // TODO: for now, all small SRAMs use the unified `io_en` signal for gating.
+  // Theoretically, gating can be set based on whether the small SRAM is activated
+  // (e.g., in cases of `setSplit` or `waySplit` is set).
+  // However, since only `DataStorage` uses this module for now
+  // and `DataStorage` reads/writes to all small SRAMs simultaneously,
+  // a unified enable signal is used for simplicity in logic.
+}


### PR DESCRIPTION
- This is a requirement from DFT,
  cause mbist needs to access each sram separately,
  and it will do so by adding addtional logic to ClockGate.
- Therefore, ClockGate need also be splitted.