### PR TITLE
fix(coupledL2): fix Poison init, add Poison for UC

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -120,6 +120,7 @@ case class L2Param(
   enableDataECC: Boolean = false,
   // DataCheck
   dataCheck: Option[String] = None,
+  enablePoison: Boolean = false,
 
   // Network layer SAM
   sam: Seq[(AddressSet, Int)] = Seq(AddressSet.everything -> 0)

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -170,8 +170,9 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     } else {
       false.B
     }
+    val poison = rxdat.bits.poison.getOrElse(false.B).orR
     denied := denied || nderr
-    corrupt := corrupt || derr || nderr || dataCheck
+    corrupt := corrupt || derr || nderr || dataCheck || poison
   }
   when (io.resp.fire) {
     s_resp := true.B
@@ -297,6 +298,11 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   txdat.bits.dataCheck match {
     case Some(x) =>
       x := dataCheck
+    case None =>
+  }
+  txdat.bits.poison match {
+    case Some(x) =>
+      x := Fill(POISON_WIDTH, req.corrupt)
     case None =>
   }
 

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -51,7 +51,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   } else {
     false.B
   }
-  val poison = io.out.bits.poision.orR
+  val poison = io.out.bits.poison.getOrElse(false.B).orR
 
   /* Write Refill Buffer*/
   io.refillBufWrite.valid := io.out.valid

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -172,7 +172,11 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         x := dataCheck
       case None =>
     }
-    dat.poision := Fill(POISON_WIDTH, task.corrupt)
+    dat.poison match {
+      case Some(x) =>
+        x := Fill(POISON_WIDTH, task.corrupt)
+      case None =>
+    }
 
     dat
   }

--- a/src/main/scala/coupledL2/tl2chi/chi/Message.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/Message.scala
@@ -298,6 +298,7 @@ trait HasCHIMsgParameters {
     case _ => 0
   }
   def enableDataCheck = dataCheckMethod != 0
+  def enablePoison = l2CacheParams.enablePoison
 
   def NODEID_WIDTH = CONFIG("NODEID_WIDTH")
 
@@ -511,7 +512,9 @@ class CHIDAT(implicit p: Parameters) extends CHIBundle {
   val dataCheck = Option.when(enableDataCheck) {
     UInt(DATACHECK_WIDTH.W)
   }
-  val poision = UInt(POISON_WIDTH.W)
+  val poison = Option.when(enablePoison) {
+    UInt(POISON_WIDTH.W)
+  }
 
   /* MSB */
 }

--- a/src/test/scala/TestTop.scala
+++ b/src/test/scala/TestTop.scala
@@ -167,6 +167,7 @@ class TestTop_L2L3()(implicit p: Parameters) extends LazyModule {
       enableTagECC = true,
       enableDataECC = true,
       dataCheck = Some("oddparity"),
+      enablePoison = true,
     )
     case BankBitsKey => 0
     case LogUtilsOptionsKey => LogUtilsOptions(
@@ -408,6 +409,7 @@ class TestTop_L2L3L2()(implicit p: Parameters) extends LazyModule {
       enableTagECC = true,
       enableDataECC = true,
       dataCheck = Some("oddparity"),
+      enablePoison = true,
     )
     case BankBitsKey => 0
     case LogUtilsOptionsKey => LogUtilsOptions(
@@ -572,6 +574,7 @@ class TestTop_fullSys()(implicit p: Parameters) extends LazyModule {
         enableTagECC = true,
         enableDataECC = true,
         dataCheck = Some("oddparity"),
+        enablePoison = true,
       )
       case BankBitsKey => 0
       case LogUtilsOptionsKey => LogUtilsOptions(

--- a/src/test/scala/chi/TestTop.scala
+++ b/src/test/scala/chi/TestTop.scala
@@ -200,6 +200,7 @@ object TestTopCHIHelper {
         // prefetch
         prefetch            = Seq(BOPParameters()),
         dataCheck           = Some("oddparity"),
+        enablePoison        = true,
 
         // using external RN-F SAM
         sam                 = Seq(AddressSet.everything -> 0)


### PR DESCRIPTION
According to CHI manual, `Poison` field should not be present in DAT packet when it's not specified or set to False.

In this pr, 
* In `TestTop`(CHI version), Poison option is set to `true` as default.
* `enablePoison` parameter is added  to `HasCHIMsgParameters`.
* `Poison` field in `TXDAT` is defined as Option Boolean variable, and its wrong name is fixed.
* `Poison` field is added for UC in MMIOBridge

