### PR TITLE
feat(TL2CIHCoupledL2): add flush L2 all operation

### DIFF
--- a/src/main/scala/coupledL2/BaseSlice.scala
+++ b/src/main/scala/coupledL2/BaseSlice.scala
@@ -37,6 +37,8 @@ abstract class BaseSliceIO[T_OUT <: BaseOuterBundle](implicit p: Parameters) ext
   val latePF = topDownOpt.map(_ => Output(Bool()))
   val error = DecoupledIO(new L2CacheErrorInfo())
   val l2Miss = Output(Bool())
+  val l2Flush = Input(Bool())
+  val l2FlushDone = Output(Bool())
 }
 
 abstract class BaseSlice[T_OUT <: BaseOuterBundle](implicit p: Parameters) extends L2Module with HasPerfEvents {

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -108,6 +108,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   // for CMO
   val cmoTask = Bool()
+  val cmoAll = Bool()
 
   // for TopDown Monitor (# TopDown)
   val reqSource = UInt(MemReqSource.reqSourceBits.W)
@@ -446,4 +447,13 @@ class PCrdGrantMatcher(val numPorts: Int) extends Module {
 class L2CacheErrorInfo(implicit p: Parameters) extends L2Bundle {
   val valid = Bool()
   val address = UInt(addressBits.W)
+}
+
+class IOCMOAll(implicit p: Parameters) extends Bundle {
+  val l2Flush = Input(Bool())
+  val l2FlushDone = Output(Bool())
+
+  val cmoLineDone = Input(Bool())
+  val mshrValid = Input(Bool())
+  val cmoAllBlock = Output(Bool())
 }

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -324,6 +324,8 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
       }
       val l2Miss = Output(Bool())
       val error = Output(new L2CacheErrorInfo()(l2ECCParams))
+      val l2Flush = Input(Bool())
+      val l2FlushDone = Output(Bool())
     })
 
     // Display info
@@ -443,6 +445,7 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
         slice.io.sliceId := i.U
 
         slice.io.error.ready := enableECC.asBool // TODO: fix the datapath as optional
+        slice.io.l2Flush := false.B /*io.l2Flush*/ //TODO: connect Core CSR 
 
         slice.io.prefetch.zip(prefetcher).foreach {
           case (s, p) =>
@@ -501,6 +504,9 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
       io.error.valid := false.B
       io.error.address := 0.U.asTypeOf(io.error.address)
     }
+
+    //L2 Flush All
+    io.l2FlushDone := VecInit(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone}).reduce(_&_)
 
     // Refill hint
     if (enableHintGuidedGrant) {

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -324,8 +324,8 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
       }
       val l2Miss = Output(Bool())
       val error = Output(new L2CacheErrorInfo()(l2ECCParams))
-      val l2Flush = Input(Bool())
-      val l2FlushDone = Output(Bool())
+//      val l2Flush = Input(Bool())
+//      val l2FlushDone = Output(Bool())
     })
 
     // Display info
@@ -506,7 +506,7 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
     }
 
     //L2 Flush All
-    io.l2FlushDone := VecInit(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone}).reduce(_&_)
+    val l2FlushDone = VecInit(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone}).reduce(_&_)
 
     // Refill hint
     if (enableHintGuidedGrant) {

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -75,6 +75,9 @@ class DirRead(implicit p: Parameters) extends L2Bundle {
   // dirRead when refill
   val refill = Bool()
   val mshrId = UInt(mshrBits.W)
+  // when flush l2
+  val cmoAll = Bool()
+  val cmoWay = UInt(wayBits.W) 
 }
 
 class DirResult(implicit p: Parameters) extends L2Bundle {
@@ -258,14 +261,14 @@ class Directory(implicit p: Parameters) extends L2Module {
     PriorityEncoder(freeWayMask_s3)
   )
 
-  val hit_s3 = Cat(hitVec).orR
-  val way_s3 = Mux(hit_s3, hitWay, finalWay)
+  val hit_s3 = Cat(hitVec).orR || req_s3.cmoAll
+  val way_s3 = Mux(req_s3.cmoAll, req_s3.cmoWay, Mux(hit_s3, hitWay, finalWay))
   val meta_s3 = metaAll_s3(way_s3)
   val tag_s3 = tagAll_s3(way_s3)(tagBits - 1, 0)
   val set_s3 = req_s3.set
   val replacerInfo_s3 = req_s3.replacerInfo
   val error_s3 = if (enableTagECC) {
-    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && meta_s3.state =/= MetaData.INVALID
+    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && !req_s3.cmoAll && meta_s3.state =/= MetaData.INVALID
   } else {
     false.B
   }

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -34,6 +34,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
     val sinkA    = Flipped(DecoupledIO(new TaskBundle))
     val ATag     = Input(UInt(tagBits.W)) // !TODO: very dirty, consider optimize structure
     val ASet     = Input(UInt(setBits.W)) // To pass A entrance status to MP for blockA-info of ReqBuf
+    val cmoAllBlock = Input(Bool())          // To block sinkC when l2 flush
     val s1Entrance = ValidIO(new L2Bundle {
       val set = UInt(setBits.W)
     })
@@ -129,7 +130,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
     (if (io.fromSourceC.isDefined) io.fromSourceC.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXDAT.isDefined) io.fromTXDAT.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXRSP.isDefined) io.fromTXRSP.get.blockSinkBReqEntrance else false.B)
-  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1
+  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1 || io.cmoAllBlock
 
 //  val noFreeWay = Wire(Bool())
 
@@ -176,6 +177,8 @@ class RequestArb(implicit p: Parameters) extends L2Module
   io.dirRead_s1.bits.replacerInfo.refill_prefetch := s1_needs_replRead && (mshr_task_s1.bits.opcode === HintAck && mshr_task_s1.bits.dsWen)
   io.dirRead_s1.bits.refill := s1_needs_replRead
   io.dirRead_s1.bits.mshrId := task_s1.bits.mshrId
+  io.dirRead_s1.bits.cmoAll := task_s1.bits.cmoAll
+  io.dirRead_s1.bits.cmoWay := task_s1.bits.way
 
   // block same-set A req
   io.s1Entrance.valid := mshr_task_s1.valid && s2_ready && mshr_task_s1.bits.metaWen || io.sinkC.fire || io.sinkB.fire

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -153,7 +153,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
    3. for each set, search all ways with a loop (0 ~ numWays)            |  io.task.way
    4. if cacheline is VALID, after cmo flush, Mainpipe send back resp    |  io.cmoAll.cmoLineDone
    5. if cacheline is INVALID, MainPipe drop it and send back resp       |  io.cmoAll.cmoLineDone
-   6. after all slices is flushed, inform Core                           |  io.l2FlushDone 
+   6. after all slices is flushed, inform Core                           |  io.cmoAll.l2FlushDone 
    7. after all slices is flushed, exit coherency                        |  TL2CHICoupledL2.io_chi.syscoreq
    ---------------------------------------------------------------------------------------------------------*/
   io.cmoAll.l2FlushDone := (state === sDONE)

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -158,13 +158,8 @@ class SinkA(implicit p: Parameters) extends L2Module {
    ---------------------------------------------------------------------------------------------------------*/
   io.cmoAll.l2FlushDone := (state === sDONE)
   io.cmoAll.cmoAllBlock := cmoAllBlock
-  dontTouch(io.cmoAll.l2FlushDone)
 
-  val counter = RegInit(0.U(32.W))
-  counter := counter+1.U
-  val l2Flush = counter > 180000.U
-
-  when (state === sIDLE && l2Flush && !io.cmoAll.mshrValid) {
+  when (state === sIDLE && io.cmoAll.l2Flush && !io.cmoAll.mshrValid) {
     state := sCMOREQ
   }
   when ((state === sCMOREQ) && io.task.fire) {

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -32,10 +32,21 @@ class SinkA(implicit p: Parameters) extends L2Module {
     val a = Flipped(DecoupledIO(new TLBundleA(edgeIn.bundle)))
     val prefetchReq = prefetchOpt.map(_ => Flipped(DecoupledIO(new PrefetchReq)))
     val task = DecoupledIO(new TaskBundle)
+    val cmoAll = new IOCMOAll
   })
   assert(!(io.a.valid && (io.a.bits.opcode === PutFullData ||
                           io.a.bits.opcode === PutPartialData)),
     "no Put");
+
+  // flush L2 all control defines
+  val numSets = 1 << setBits 
+  val numWays = 1 << wayBits
+  val set = RegInit(0.U(setBits.W))
+  val way = RegInit(0.U(wayBits.W)) 
+  val sIDLE :: sCMOREQ :: sWAITLINE :: sWAITMSHR :: sDONE :: Nil = Enum(5)
+  val state = RegInit(sIDLE)
+  val cmoAllValid = (state ===sCMOREQ)
+  val cmoAllBlock = (state ===sCMOREQ) || (state === sWAITLINE)
 
   def fromTLAtoTaskBundle(a: TLBundleA): TaskBundle = {
     val task = Wire(new TaskBundle)
@@ -43,10 +54,10 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.channel := "b001".U
     task.txChannel := 0.U
     task.tag := parseAddress(a.address)._1
-    task.set := parseAddress(a.address)._2
+    task.set := Mux(cmoAllValid, set, parseAddress(a.address)._2)
     task.off := parseAddress(a.address)._3
     task.alias.foreach(_ := a.user.lift(AliasKey).getOrElse(0.U))
-    task.opcode := a.opcode
+    task.opcode := Mux(cmoAllValid, 13.U, a.opcode)
     task.param := a.param
     task.size := a.size
     task.sourceId := a.source
@@ -61,7 +72,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
-    task.way := 0.U(wayBits.W)
+    task.way := Mux(cmoAllValid, way, 0.U(wayBits.W))
     task.meta := 0.U.asTypeOf(new MetaEntry)
     task.metaWen := false.B
     task.tagWen := false.B
@@ -74,6 +85,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.isKeyword.foreach(_ := a.echo.lift(IsKeywordKey).getOrElse(false.B))
     task.mergeA := false.B
     task.aMergeTask := 0.U.asTypeOf(new MergeTaskBundle)
+    task.cmoAll := cmoAllValid
     task
   }
   def fromPrefetchReqtoTaskBundle(req: PrefetchReq): TaskBundle = {
@@ -115,19 +127,68 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task
   }
   if (prefetchOpt.nonEmpty) {
-    io.task.valid := io.a.valid || io.prefetchReq.get.valid
+    io.task.valid := io.a.valid && !io.cmoAll.cmoAllBlock || io.prefetchReq.get.valid || cmoAllValid
     io.task.bits := Mux(
       io.a.valid,
       fromTLAtoTaskBundle(io.a.bits),
       fromPrefetchReqtoTaskBundle(io.prefetchReq.get.bits
     ))
 
-    io.a.ready := io.task.ready
+    io.a.ready := io.task.ready && !io.cmoAll.cmoAllBlock
     io.prefetchReq.get.ready := io.task.ready && !io.a.valid
   } else {
-    io.task.valid := io.a.valid
-    io.task.bits := fromTLAtoTaskBundle(io.a.bits)
-    io.a.ready := io.task.ready
+    io.task.valid := io.a.valid && !io.cmoAll.cmoAllBlock || cmoAllValid
+    io.task.bits := fromTLAtoTaskBundle(io.a.bits) 
+    io.a.ready := io.task.ready && !io.cmoAll.cmoAllBlock
+  }
+
+  /*
+   Flush L2 All means search all L2$ VALID cacheLine and RELEASE to Downwords memory:
+   -------------------------------------------------------------------------------------------------------
+          Step by Step                                                   |    Interface 
+   ----------------------------------------------------------------------|--------------------------------
+   0. Core initiate flush L2$ All operation                              |  io.cmoAll.l2Flush 
+   1. wait all mshrs done, block sinkA/C by ready until l2 flush done    |  io.cmoAll.cmoAllBlock 
+   2. search all cacheline set with a loop (0 ~ numSets)                 |  io.task.set
+   3. for each set, search all ways with a loop (0 ~ numWays)            |  io.task.way
+   4. if cacheline is VALID, after cmo flush, Mainpipe send back resp    |  io.cmoAll.cmoLineDone
+   5. if cacheline is INVALID, MainPipe drop it and send back resp       |  io.cmoAll.cmoLineDone
+   6. after all slices is flushed, inform Core                           |  io.l2FlushDone 
+   7. after all slices is flushed, exit coherency                        |  TL2CHICoupledL2.io_chi.syscoreq
+   ---------------------------------------------------------------------------------------------------------*/
+  io.cmoAll.l2FlushDone := (state === sDONE)
+  io.cmoAll.cmoAllBlock := cmoAllBlock
+  dontTouch(io.cmoAll.l2FlushDone)
+
+  val counter = RegInit(0.U(32.W))
+  counter := counter+1.U
+  val l2Flush = counter > 180000.U
+
+  when (state === sIDLE && l2Flush && !io.cmoAll.mshrValid) {
+    state := sCMOREQ
+  }
+  when ((state === sCMOREQ) && io.task.fire) {
+    state := sWAITLINE
+  }
+  when (state === sWAITLINE && (io.cmoAll.cmoLineDone)) {
+    when (set===(numSets-1).U && way===(numWays-1).U) { 
+      state := sDONE
+    }.otherwise {
+      when(way ===(numWays -1).U) {
+        way:=0.U
+        set:=set+1.U
+      }.otherwise {
+        way:=way+1.U
+      }
+      when (!io.cmoAll.mshrValid) {
+        state := sCMOREQ
+      }.otherwise {
+        state := sWAITMSHR
+      }
+    }
+  }
+  when ((state === sWAITMSHR) && !io.cmoAll.mshrValid) {
+    state := sCMOREQ
   }
 
   // Performance counters

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -116,7 +116,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /* l2 flush (CMO All) */
     val cmoAllBlock = Input(Bool())
     val cmoLineDone = Output(Bool())
-  })
+})
 
   require(chiOpt.isDefined)
 

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -112,6 +112,10 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
     /* ECC error*/
     val error = ValidIO(new L2CacheErrorInfo)
+
+    /* l2 flush (CMO All) */
+    val cmoAllBlock = Input(Bool())
+    val cmoLineDone = Output(Bool())
   })
 
   require(chiOpt.isDefined)
@@ -161,7 +165,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val req_prefetch_s3           = sinkA_req_s3 && req_s3.opcode === Hint
   val req_get_s3                = sinkA_req_s3 && req_s3.opcode === Get
   val req_cbo_clean_s3          = sinkA_req_s3 && req_s3.opcode === CBOClean
-  val req_cbo_flush_s3          = sinkA_req_s3 && req_s3.opcode === CBOFlush
+  val req_cbo_flush_s3          = sinkA_req_s3 && req_s3.opcode === CBOFlush && !(io.cmoAllBlock && (meta_s3.state === INVALID))
   val req_cbo_inval_s3          = sinkA_req_s3 && req_s3.opcode === CBOInval
 
   val mshr_grant_s3             = mshr_req_s3 && req_s3.fromA && (req_s3.opcode === Grant || req_s3.opcode === GrantData)
@@ -567,12 +571,12 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val txdat_s3_latch = true
   val isD_s3 = Mux(
     mshr_req_s3,
-    mshr_cmoresp_s3 || mshr_refill_s3 && !retry,
-    req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint
+    mshr_cmoresp_s3 && !io.cmoAllBlock|| mshr_refill_s3 && !retry,
+    req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint && !io.cmoAllBlock
   )
   val isD_s3_ready = Mux(
     mshr_req_s3,
-    mshr_cmoresp_s3 || mshr_refill_s3 && !retry,
+    mshr_cmoresp_s3 && !io.cmoAllBlock || mshr_refill_s3 && !retry,
     req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint && !d_s3_latch.B
   )
   val isTXRSP_s3 = Mux(
@@ -927,6 +931,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.error.bits.valid := l2Error_s5 // if not enableECC, should be false
   io.error.bits.address := Cat(task_s5.bits.tag, task_s5.bits.set, task_s5.bits.off)
 
+  val cmoLineDrop = io.cmoAllBlock && task_s3.valid && sinkA_req_s3 && (req_s3.opcode === CBOFlush)  && (meta_s3.state === INVALID)
+  val cmoLineDone = io.cmoAllBlock && task_s3.valid && mshr_cmoresp_s3
+  io.cmoLineDone := RegNextN( ( cmoLineDone || cmoLineDrop) , 2, Some(false.B))
   /* ===== Performance counters ===== */
   // num of mshr req
   XSPerfAccumulate("mshr_grant_req", task_s3.valid && mshr_grant_s3 && !retry)

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -931,7 +931,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.error.bits.valid := l2Error_s5 // if not enableECC, should be false
   io.error.bits.address := Cat(task_s5.bits.tag, task_s5.bits.set, task_s5.bits.off)
 
-  val cmoLineDrop = io.cmoAllBlock && task_s3.valid && sinkA_req_s3 && (req_s3.opcode === CBOFlush)  && (meta_s3.state === INVALID)
+  val cmoLineDrop = io.cmoAllBlock && task_s3.valid && sinkA_req_s3 && (req_s3.opcode === CBOFlush) && (meta_s3.state === INVALID)
   val cmoLineDone = io.cmoAllBlock && task_s3.valid && mshr_cmoresp_s3
   io.cmoLineDone := RegNextN( ( cmoLineDone || cmoLineDrop) , 2, Some(false.B))
   /* ===== Performance counters ===== */

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -931,6 +931,10 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.error.bits.valid := l2Error_s5 // if not enableECC, should be false
   io.error.bits.address := Cat(task_s5.bits.tag, task_s5.bits.set, task_s5.bits.off)
 
+  /* CMO All Flush cacheline done if:
+   cacheline is INVALID -> drop @s3
+   cacheline is VALID send back resp when mshr complete CBOFlush flow
+   */
   val cmoLineDrop = io.cmoAllBlock && task_s3.valid && sinkA_req_s3 && (req_s3.opcode === CBOFlush) && (meta_s3.state === INVALID)
   val cmoLineDone = io.cmoAllBlock && task_s3.valid && mshr_cmoresp_s3
   io.cmoLineDone := RegNextN( ( cmoLineDone || cmoLineDrop) , 2, Some(false.B))

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -92,6 +92,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
 
   reqArb.io.ATag := reqBuf.io.ATag
   reqArb.io.ASet := reqBuf.io.ASet
+  reqArb.io.cmoAllBlock := sinkA.io.cmoAll.cmoAllBlock
   reqArb.io.sinkA <> reqBuf.io.out
   reqArb.io.sinkB <> rxsnp.io.task
   reqArb.io.sinkC <> sinkC.io.task
@@ -208,6 +209,13 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   rxrsp.io.out <> io.out.rx.rsp
 
   io_pCrd <> mshrCtl.io.pCrd
+
+  /* Connect l2 flush All channel */ 
+  sinkA.io.cmoAll.cmoLineDone <> mainPipe.io.cmoLineDone
+  sinkA.io.cmoAll.mshrValid := VecInit(mshrCtl.io.msInfo.map(m => m.valid)).reduce(_|_)
+  sinkA.io.cmoAll.cmoAllBlock <> mainPipe.io.cmoAllBlock
+  sinkA.io.cmoAll.l2Flush <> io.l2Flush
+  io.l2FlushDone <> sinkA.io.cmoAll.l2FlushDone
 
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -215,7 +215,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   sinkA.io.cmoAll.mshrValid := VecInit(mshrCtl.io.msInfo.map(m => m.valid)).reduce(_|_)
   sinkA.io.cmoAll.cmoAllBlock <> mainPipe.io.cmoAllBlock
   sinkA.io.cmoAll.l2Flush <> io.l2Flush
-  io.l2FlushDone <> sinkA.io.cmoAll.l2FlushDone
+  io.l2FlushDone <> RegNext(sinkA.io.cmoAll.l2FlushDone, false.B)
 
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -255,6 +255,8 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         rxdat <> linkMonitor.io.in.rx.dat
         io_chi <> linkMonitor.io.out
         linkMonitor.io.nodeID := io_nodeID
+        linkMonitor.io.exitco := Cat(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone}).andR //exit coherency
+
     }
   }
 

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -303,15 +303,6 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   LCredit2Decoupled(io.out.rx.rsp, io.in.rx.rsp, LinkState(rxState), rxrspDeact, Some("rxrsp"))
   LCredit2Decoupled(io.out.rx.dat, io.in.rx.dat, LinkState(rxState), rxdatDeact, Some("rxdat"))
 
-//  io.out.txsactive := true.B
-//  io.out.tx.linkactivereq := RegNext(true.B, init = false.B)
-//  io.out.rx.linkactiveack := RegNext(
-//    next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
-//    init = false.B
-//  )
-
-//  io.out.syscoreq := true.B
-
   //exit coherecy + deactive tx/rx when l2 flush done
   io.out.txsactive := !io.exitco
   io.out.tx.linkactivereq := RegNext(!io.exitco, init = false.B)
@@ -321,8 +312,6 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   )
 
   io.out.syscoreq := !io.exitco
-
-
 
   val retryAckCnt = RegInit(0.U(64.W))
   val pCrdGrantCnt = RegInit(0.U(64.W))

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -310,7 +310,6 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     next = !io.exitco && (RegNext(io.out.rx.linkactivereq) || !rxDeact),
     init = false.B
   )
-
   io.out.syscoreq := !io.exitco
 
   val retryAckCnt = RegInit(0.U(64.W))

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -107,6 +107,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
 
     /* ECC error*/
     val error = ValidIO(new L2CacheErrorInfo)
+
   })
 
   val resetFinish = RegInit(false.B)
@@ -247,6 +248,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.snpHitReleaseDirty := false.B
   ms_task.denied           := false.B
   ms_task.corrupt          := false.B
+  ms_task.corrupt          := false.B
+  ms_task.cmoAll           := false.B
 
   /* ======== Resps to SinkA/B/C Reqs ======== */
   val sink_resp_s3 = WireInit(0.U.asTypeOf(Valid(new TaskBundle))) // resp for sinkA/B/C request that does not need to alloc mshr

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -171,6 +171,13 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   refillUnit.io.sinkD <> outBuf.d(io.out.d)
   io.out.e <> outBuf.e(refillUnit.io.sourceE)
 
+  /* tie cmo All channels */
+  sinkA.io.cmoAll.cmoLineDone := false.B
+  sinkA.io.cmoAll.mshrValid := false.B
+  sinkA.io.cmoAll.l2Flush := false.B
+  io.l2FlushDone := false.B
+  reqArb.io.cmoAllBlock := false.B
+
   dontTouch(io.in)
   dontTouch(io.out)
 


### PR DESCRIPTION
    feat(TL2CIHCoupledL2): add flush L2 all operation to search all VALID cacheline to release to memory

    * Core initiate flush L2$ all operation by core and L2 interface <io.l2Flush>
    * The Barrior is added to wait all mshrs done before l2 flush begin
    * The FSM in SinkA is added to insert 'CBO_FLUSH' with set/way task to main pipe
    * The set/way are generated by the set loop(0~numSets) and way loop(0~numWays)
    * If cacheline is VALID, after cbo flush, main pipe send back resp to sinkA
    * if cacheline is INVALID, main pipe drop it and send back resp to sinkA
    * During the process, sinkA/C is blocked by ready until l2 flush done
    * Snoop operations from sinkB is allowed to enter into mainpipe
    * After all slices done, inform Core and exit coherency and deactive rx/tx in linklayer
