### PR TITLE
fix(MSHR): MSHR RXDAT's corrupt includes DataCheck/Poison

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,8 @@ jobs:
       # Clean artifacts folder (./tl-test-new/run) after successful run
       - name: Unit test for CHI version
         run: |
+            rm -rf tl-test-new
+            git clone https://github.com/OpenXiangShan/tl-test-new
             cd ./tl-test-new
             sed -i 's/ari.target.*/ari.target = 240/g' ./configs/user.tltest.ini
             sed -i 's/cmo.enable .*=.*/cmo.enable = 1/g' ./configs/user.tltest.ini
@@ -93,6 +95,7 @@ jobs:
       # Clean artifacts folder (./tl-test-new/run) after successful run
       - name: Unit Test for TileLink version
         run: |
+            rm -rf tl-test-new
             git clone https://github.com/OpenXiangShan/tl-test-new
             cd ./tl-test-new
             sed -i 's/ari.target.*/ari.target = 240/g' ./configs/user.tltest.ini

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,22 +68,6 @@ jobs:
         run: make compile
       
       # Clean artifacts folder (./tl-test-new/run) after successful run
-      - name: Unit Test for TileLink version
-        run: |
-            git clone https://github.com/OpenXiangShan/tl-test-new
-            cd ./tl-test-new
-            sed -i 's/ari.target.*/ari.target = 240/g' ./configs/user.tltest.ini
-            rm -rf ./dut/CoupledL2 && ln -s ../.. ./dut/CoupledL2
-            make coupledL2-test-l2l3l2 run THREADS_BUILD=4 CXX_COMPILER=clang++-17
-            rm -rf run/*.vcd run/*.fst run/*.log run/*.db
-
-      - name: Tar up artifacts of Unit Test for TileLink version
-        if: always()
-        run: |
-            test -d ./tl-test-new/run || mkdir -p ./tl-test-new/run
-            tar -zcf ${{ env.RUN_ARCHIVE_TL }} ./tl-test-new/run
-
-      # Clean artifacts folder (./tl-test-new/run) after successful run
       - name: Unit test for CHI version
         run: |
             cd ./tl-test-new
@@ -105,6 +89,22 @@ jobs:
         run: |
             test -d ./tl-test-new/run || mkdir -p ./tl-test-new/run
             tar -zcf ${{ env.RUN_ARCHIVE_CHI }} ./tl-test-new/run
+      
+      # Clean artifacts folder (./tl-test-new/run) after successful run
+      - name: Unit Test for TileLink version
+        run: |
+            git clone https://github.com/OpenXiangShan/tl-test-new
+            cd ./tl-test-new
+            sed -i 's/ari.target.*/ari.target = 240/g' ./configs/user.tltest.ini
+            rm -rf ./dut/CoupledL2 && ln -s ../.. ./dut/CoupledL2
+            make coupledL2-test-l2l3l2 run THREADS_BUILD=4 CXX_COMPILER=clang++-17
+            rm -rf run/*.vcd run/*.fst run/*.log run/*.db
+
+      - name: Tar up artifacts of Unit Test for TileLink version
+        if: always()
+        run: |
+            test -d ./tl-test-new/run || mkdir -p ./tl-test-new/run
+            tar -zcf ${{ env.RUN_ARCHIVE_TL }} ./tl-test-new/run
 
       - name: Upload artifacts of Unit Test
         if: always()

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -119,8 +119,8 @@ case class L2Param(
   enableTagECC: Boolean = false,
   enableDataECC: Boolean = false,
   // DataCheck
-  dataCheck: Option[String] = None,
-  enablePoison: Boolean = false,
+  dataCheck: Option[String] = Some("oddparity"),
+  enablePoison: Boolean = true,
 
   // Network layer SAM
   sam: Seq[(AddressSet, Int)] = Seq(AddressSet.everything -> 0)

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -171,6 +171,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       false.B
     }
     val poison = rxdat.bits.poison.getOrElse(false.B).orR
+    assert(!(dataCheck || poison), "UC should not have DataCheck/Poison error")
     denied := denied || nderr
     corrupt := corrupt || derr || nderr || dataCheck || poison
   }

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -160,11 +160,11 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
     val dataCheck = if (enableDataCheck) {
       dataCheckMethod match {
         case 1 => (0 until DATACHECK_WIDTH).map(i =>
-          rxdat.bits.dataCheck.get(i) ^ rdata(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
+          rxdat.bits.dataCheck.get(i) ^ rxdat.bits.data(8 * (i + 1) - 1, 8 * i).xorR ^ true.B).reduce(_ | _)
         case 2 =>
           val code = new SECDEDCode
           (0 until DATACHECK_WIDTH).map(i =>
-            code.decode(Cat(rxdat.bits.dataCheck.get(i) ^ rdata(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
+            code.decode(Cat(rxdat.bits.dataCheck.get(i) ^ rxdat.bits.data(8 * (i + 1) - 1, 8 * i))).error).reduce(_ | _)
         case _ => false.B
       }
     } else {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1103,6 +1103,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   when (rxdat.valid) {
     val nderr = rxdat.bits.respErr.getOrElse(OK) === NDERR
     val derr = rxdat.bits.respErr.getOrElse(OK) === DERR
+    val rxdatCorrupt = rxdat.bits.corrupt
     ifAfterIssueC {
       when (rxdat.bits.chiOpcode.get === DataSepResp) {
         require(beatSize == 2) // TODO: This is ugly
@@ -1113,7 +1114,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         gotDirty := gotDirty || rxdatIsU_PD
         gotGrantData := true.B
         denied := denied || nderr
-        corrupt := corrupt || derr || nderr
+        corrupt := corrupt || derr || nderr || rxdatCorrupt
       }
     }
 

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -52,7 +52,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
     false.B
   }
   val poison = io.out.bits.poison.getOrElse(false.B).orR
-  assert(!(dataCheck || poison), "RXDAT(cached) should not have DataCheck/Poison error")
+  assert(!((dataCheck || poison) && io.out.valid), "RXDAT(cached) should not have DataCheck/Poison error")
 
   /* Write Refill Buffer*/
   io.refillBufWrite.valid := io.out.valid

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -52,6 +52,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
     false.B
   }
   val poison = io.out.bits.poison.getOrElse(false.B).orR
+  assert(!(dataCheck || poison), "RXDAT(cached) should not have DataCheck/Poison error")
 
   /* Write Refill Buffer*/
   io.refillBufWrite.valid := io.out.valid


### PR DESCRIPTION
Previous, `MSHR` RXDAT's corrupt does not include `io.resp.rxdat.bits.corrupt`.
Consequently, `DataCheck/Poison` fields in `RXDAT` are not actually used.

In this pr:
* `MSHR` RXDAT's corrupt includes corresponding `DataCheck/Poison`.
* Assertions about `DataCheck/Poison` are added to RXDAT channel.
   `DataCheck/Poison` error should not exist in simulation.
