### PR TITLE
fix(CoupledL2): use RR FastArbiter for L1 Hint dequeue

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -497,7 +497,7 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
     if (enableHintGuidedGrant) {
       // for timing consideration, hint should latch one cycle before sending to L1
       // instead of adding a Pipeline/Queue to latch here, we just set hintQueue in GrantBuf & CustomL1Hint "flow=false"
-      val l1HintArb = Module(new Arbiter(new L2ToL1Hint(), slices.size))
+      val l1HintArb = Module(new FastArbiter(new L2ToL1Hint(), slices.size))
       val slices_l1Hint = slices.zipWithIndex.map {
         case (s, i) => s.io.l1Hint
       }


### PR DESCRIPTION
* Simple ```Aribter``` causing congestion of **L1 Hint Queue** and **GrantBuffer** might result in performance impact on Acquire/Grants.