### PR TITLE
chore(DataStorage): modify data name of ECC encode unit in DS

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -41,6 +41,7 @@ trait HasCoupledL2Parameters {
   def XLEN = 64
   def blocks = cacheParams.sets * cacheParams.ways
   def blockBytes = cacheParams.blockBytes
+  def blockBits = blockBytes * 8
   def beatBytes = cacheParams.channelBytes.d.get
   def beatSize = blockBytes / beatBytes
 
@@ -72,18 +73,14 @@ trait HasCoupledL2Parameters {
   // ECC
   def enableECC = cacheParams.enableTagECC || cacheParams.enableDataECC
   def enableTagECC = cacheParams.enableTagECC
-  def eccDataBankSplit = 4 // SRAM dataSplit = 4
+  def dataBankSplit = 4 // SRAM dataSplit = 4
   def encTagBits = cacheParams.tagCode.width(tagBits)
   def eccTagBits = encTagBits - tagBits
   def enableDataECC = cacheParams.enableDataECC
-  def eccWordBits = 64
-  def eccBankWord = 2
-  def eccBankBits = eccWordBits * eccBankWord
-  def encDataBits = cacheParams.dataCode.width(eccBankBits * 4)
-  def eccDataBits = encDataBits - eccBankBits * 4
-  def encDataPaddingBits = ((encDataBits + 3) / eccDataBankSplit) * eccDataBankSplit
-  def encDataBankBits = cacheParams.dataCode.width(eccBankBits)
-  def eccDataBankBits = encDataBits - eccBankBits
+  def wordBits = 64
+  def bankWords = blockBits / wordBits / dataBankSplit
+  def dataBankBits = wordBits * bankWords
+  def encBankBits = cacheParams.dataCode.width(dataBankBits)
 
   // Prefetch
   def prefetchers = cacheParams.prefetch

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -76,11 +76,12 @@ trait HasCoupledL2Parameters {
   def encTagBits = cacheParams.tagCode.width(tagBits)
   def eccTagBits = encTagBits - tagBits
   def enableDataECC = cacheParams.enableDataECC
-  def encDataBits = cacheParams.dataCode.width(blockBytes * 8)
-  def eccDataBits = encDataBits - blockBytes * 8
+  def eccDataBlockBits = blockBytes * 8 / 8
+  def encDataBits = cacheParams.dataCode.width(eccDataBlockBits * 8)
+  def eccDataBits = encDataBits - eccDataBlockBits * 8
   def encDataPaddingBits = ((encDataBits + 3) / eccDataBankSplit) * eccDataBankSplit
-  def encDataBankBits = cacheParams.dataCode.width(blockBytes * 2)
-  def eccDataBankBits = encDataBits - blockBytes * 2
+  def encDataBankBits = cacheParams.dataCode.width(eccDataBlockBits * 2)
+  def eccDataBankBits = encDataBits - eccDataBlockBits * 2
 
   // Prefetch
   def prefetchers = cacheParams.prefetch

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -76,12 +76,14 @@ trait HasCoupledL2Parameters {
   def encTagBits = cacheParams.tagCode.width(tagBits)
   def eccTagBits = encTagBits - tagBits
   def enableDataECC = cacheParams.enableDataECC
-  def eccDataBlockBits = blockBytes * 8 / 8
-  def encDataBits = cacheParams.dataCode.width(eccDataBlockBits * 8)
-  def eccDataBits = encDataBits - eccDataBlockBits * 8
+  def eccWordBits = 64
+  def eccBankWord = 2
+  def eccBankBits = eccWordBits * eccBankWord
+  def encDataBits = cacheParams.dataCode.width(eccBankBits * 4)
+  def eccDataBits = encDataBits - eccBankBits * 4
   def encDataPaddingBits = ((encDataBits + 3) / eccDataBankSplit) * eccDataBankSplit
-  def encDataBankBits = cacheParams.dataCode.width(eccDataBlockBits * 2)
-  def eccDataBankBits = encDataBits - eccDataBlockBits * 2
+  def encDataBankBits = cacheParams.dataCode.width(eccBankBits)
+  def eccDataBankBits = encDataBits - eccBankBits
 
   // Prefetch
   def prefetchers = cacheParams.prefetch

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -35,14 +35,14 @@ class DSBeat(implicit p: Parameters) extends L2Bundle {
 }
 
 class DSBlock(implicit p: Parameters) extends L2Bundle {
-  val data = UInt((blockBytes * 8).W)
+  val data = UInt((eccDataBlockBits * 8).W)
 }
 
 class DSECCBlock(implicit p: Parameters) extends L2Bundle {
   val data = if (enableDataECC) {
     UInt(encDataPaddingBits.W)
   } else {
-    UInt((blockBytes * 8).W)
+    UInt((eccDataBlockBits * 8).W)
   }
 }
 
@@ -50,7 +50,7 @@ class DSECCBankBlock(implicit p: Parameters) extends L2Bundle {
   val data = if (enableDataECC) {
     UInt((encDataBankBits * 4).W)
   } else {
-    UInt((blockBytes * 8).W)
+    UInt((eccDataBlockBits * 8).W)
   }
 }
 
@@ -91,7 +91,8 @@ class DataStorage(implicit p: Parameters) extends L2Module {
   val arrayWrite = Wire(new DSECCBankBlock)
   val arrayWriteData = if (enableDataECC) {
     // cacheParams.dataCode.encode(io.wdata.data).pad(encDataPaddingBits)
-    Cat(VecInit(Seq.tabulate(4)(i => io.wdata.data((blockBytes * 2) * (i + 1) - 1, (blockBytes * 2) * i))).map(data => cacheParams.dataCode.encode(data)))
+    Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i =>
+      io.wdata.data((eccDataBlockBits * 2) * (i + 1) - 1, (eccDataBlockBits * 2) * i))).map(data => cacheParams.dataCode.encode(data)))
   } else {
     io.wdata.data
   }
@@ -99,9 +100,9 @@ class DataStorage(implicit p: Parameters) extends L2Module {
 
   val arrayRead = array.io.r.resp.data(0)
   val dataRead = Wire(new DSBlock)
-  // dataRead.data := arrayRead.data(blockBytes * 8 - 1, 0)
+  // dataRead.data := arrayRead.data(eccDataBlockBits * 8 - 1, 0)
   val bankDataRead = if (enableDataECC) {
-    Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i => arrayRead.data(encDataBankBits * (i + 1) - 1, encDataBankBits * i)(blockBytes * 2 - 1, 0))))
+    Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i => arrayRead.data(encDataBankBits * (i + 1) - 1, encDataBankBits * i)(eccDataBlockBits * 2 - 1, 0))))
   } else {
     arrayRead.data
   }

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -35,14 +35,14 @@ class DSBeat(implicit p: Parameters) extends L2Bundle {
 }
 
 class DSBlock(implicit p: Parameters) extends L2Bundle {
-  val data = UInt((eccDataBlockBits * 8).W)
+  val data = UInt((eccBankBits * 4).W)
 }
 
 class DSECCBlock(implicit p: Parameters) extends L2Bundle {
   val data = if (enableDataECC) {
     UInt(encDataPaddingBits.W)
   } else {
-    UInt((eccDataBlockBits * 8).W)
+    UInt((eccBankBits * 4).W)
   }
 }
 
@@ -50,7 +50,7 @@ class DSECCBankBlock(implicit p: Parameters) extends L2Bundle {
   val data = if (enableDataECC) {
     UInt((encDataBankBits * 4).W)
   } else {
-    UInt((eccDataBlockBits * 8).W)
+    UInt((eccBankBits * 4).W)
   }
 }
 
@@ -92,7 +92,7 @@ class DataStorage(implicit p: Parameters) extends L2Module {
   val arrayWriteData = if (enableDataECC) {
     // cacheParams.dataCode.encode(io.wdata.data).pad(encDataPaddingBits)
     Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i =>
-      io.wdata.data((eccDataBlockBits * 2) * (i + 1) - 1, (eccDataBlockBits * 2) * i))).map(data => cacheParams.dataCode.encode(data)))
+      io.wdata.data(eccBankBits * (i + 1) - 1, eccBankBits * i))).map(data => cacheParams.dataCode.encode(data)))
   } else {
     io.wdata.data
   }
@@ -100,9 +100,9 @@ class DataStorage(implicit p: Parameters) extends L2Module {
 
   val arrayRead = array.io.r.resp.data(0)
   val dataRead = Wire(new DSBlock)
-  // dataRead.data := arrayRead.data(eccDataBlockBits * 8 - 1, 0)
+  // dataRead.data := arrayRead.data(eccBankBits * 4 - 1, 0)
   val bankDataRead = if (enableDataECC) {
-    Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i => arrayRead.data(encDataBankBits * (i + 1) - 1, encDataBankBits * i)(eccDataBlockBits * 2 - 1, 0))))
+    Cat(VecInit(Seq.tabulate(eccDataBankSplit)(i => arrayRead.data(encDataBankBits * (i + 1) - 1, encDataBankBits * i)(eccBankBits - 1, 0))))
   } else {
     arrayRead.data
   }

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -113,7 +113,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   val isBackTypeMM = req.user.lift(MemBackTypeMM).getOrElse(false.B)
   val isPageTypeNC = req.user.lift(MemPageTypeNC).getOrElse(false.B)
 
-  val wordBits = io.req.bits.data.getWidth // 64
+  require(io.req.bits.data.getWidth == wordBits)
   val wordBytes = wordBits / 8
   val words = DATA_WIDTH / wordBits
   val wordIdxBits = log2Ceil(words)


### PR DESCRIPTION
In this pr:
* Modify data name of ECC encode unit in DS.
   Previous, `blockBytes` is wrongly used, now replaced by `eccDataBlockBits`
* Parameterize `4` to `eccDataBankSplit`