### PR TITLE
fix(MMIOBridge, MSHR): Poison may be asserted

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -171,7 +171,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       false.B
     }
     val poison = rxdat.bits.poison.getOrElse(false.B).orR
-    assert(!(dataCheck || poison), "UC should not have DataCheck/Poison error")
+    assert(!dataCheck, "UC should not have DataCheck error")
     denied := denied || nderr
     corrupt := corrupt || derr || nderr || dataCheck || poison
   }

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1129,7 +1129,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       dbid := rxdat.bits.dbID.getOrElse(0.U)
       homenid := rxdat.bits.homeNID.getOrElse(0.U)
       denied := denied || nderr
-      corrupt := corrupt || derr || nderr
+      corrupt := corrupt || derr || nderr || rxdatCorrupt
       req.traceTag.get := req.traceTag.get || rxdat.bits.traceTag.getOrElse(false.B)
     }
   }

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -52,7 +52,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
     false.B
   }
   val poison = io.out.bits.poison.getOrElse(false.B).orR
-  assert(!((dataCheck || poison) && io.out.valid), "RXDAT(cached) should not have DataCheck/Poison error")
+  assert(!(dataCheck && io.out.valid), "RXDAT(cached) should not have DataCheck error")
 
   /* Write Refill Buffer*/
   io.refillBufWrite.valid := io.out.valid


### PR DESCRIPTION
- When DataCheck fails or Poison bits are asserted in CompData, L2 should report `corrupt` to L1. The previous design only considers DataSepResp but omits CompData.
- If there is no slave device in the interconnect to handle the request, error device, for example, will return SLVERR, which is transitioned into Poison in CHI interconnect. Therefore we should not assume that Poison is never asserted. The commit removes assertion check for Poison.