### PR TITLE
feat(TL2CIHCoupledL2): add flush L2 all operation to search all VALID cacheline to release to memory

### DIFF
--- a/src/main/scala/coupledL2/BaseSlice.scala
+++ b/src/main/scala/coupledL2/BaseSlice.scala
@@ -37,6 +37,8 @@ abstract class BaseSliceIO[T_OUT <: BaseOuterBundle](implicit p: Parameters) ext
   val latePF = topDownOpt.map(_ => Output(Bool()))
   val error = DecoupledIO(new L2CacheErrorInfo())
   val l2Miss = Output(Bool())
+  val l2Flush = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
+  val l2FlushDone = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
 }
 
 abstract class BaseSlice[T_OUT <: BaseOuterBundle](implicit p: Parameters) extends L2Module with HasPerfEvents {

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -108,6 +108,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   // for CMO
   val cmoTask = Bool()
+  val cmoAll = Bool()
 
   // for TopDown Monitor (# TopDown)
   val reqSource = UInt(MemReqSource.reqSourceBits.W)
@@ -454,4 +455,12 @@ class PCrdGrantMatcher(val numPorts: Int) extends Module {
 class L2CacheErrorInfo(implicit p: Parameters) extends L2Bundle {
   val valid = Bool()
   val address = UInt(addressBits.W)
+}
+class IOCMOAll(implicit p: Parameters) extends Bundle {
+  val l2Flush = Input(Bool())
+  val l2FlushDone = Output(Bool())
+
+  val cmoLineDone = Input(Bool())
+  val mshrValid = Input(Bool())
+  val cmoAllBlock = Output(Bool())
 }

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -316,7 +316,10 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
       }
       val l2Miss = Output(Bool())
       val error = Output(new L2CacheErrorInfo()(l2ECCParams))
+//      val l2Flush = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
+//      val l2FlushDone = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
     })
+
 
     // Display info
     val sizeBytes = cacheParams.toCacheParams.capacity.toDouble
@@ -435,6 +438,9 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
 
         slice.io.error.ready := enableECC.asBool // TODO: fix the datapath as optional
 
+//      slice.io.l2Flush.foreach(_ := io.l2Flush.getOrElse(false.B))
+        slice.io.l2Flush.foreach(_ := false.B)
+
         slice.io.prefetch.zip(prefetcher).foreach {
           case (s, p) =>
             s.req.valid := p.io.req.valid && bank_eq(p.io.req.bits.set, i, bankBits)
@@ -492,6 +498,9 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
       io.error.valid := false.B
       io.error.address := 0.U.asTypeOf(io.error.address)
     }
+
+    //L2 Flush Done
+    //io.l2FlushDone.foreach(_ :=  VecInit(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone.getOrElse(false.B)}).reduce(_&_) )
 
     // Refill hint
     if (enableHintGuidedGrant) {

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -75,6 +75,9 @@ class DirRead(implicit p: Parameters) extends L2Bundle {
   // dirRead when refill
   val refill = Bool()
   val mshrId = UInt(mshrBits.W)
+  // when flush l2
+  val cmoAll = Bool()
+  val cmoWay = UInt(wayBits.W) 
 }
 
 class DirResult(implicit p: Parameters) extends L2Bundle {
@@ -257,15 +260,14 @@ class Directory(implicit p: Parameters) extends L2Module {
     chosenWay,
     PriorityEncoder(freeWayMask_s3)
   )
-
-  val hit_s3 = Cat(hitVec).orR
-  val way_s3 = Mux(hit_s3, hitWay, finalWay)
+  val hit_s3 = Cat(hitVec).orR || req_s3.cmoAll
+  val way_s3 = Mux(req_s3.cmoAll, req_s3.cmoWay, Mux(hit_s3, hitWay, finalWay))
   val meta_s3 = metaAll_s3(way_s3)
   val tag_s3 = tagAll_s3(way_s3)(tagBits - 1, 0)
   val set_s3 = req_s3.set
   val replacerInfo_s3 = req_s3.replacerInfo
   val error_s3 = if (enableTagECC) {
-    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && meta_s3.state =/= MetaData.INVALID
+    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && !req_s3.cmoAll && meta_s3.state =/= MetaData.INVALID
   } else {
     false.B
   }

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -99,6 +99,8 @@ case class L2Param(
   hartId: Int = 0,
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
+  // L2 Flush
+  enableL2Flush: Boolean = true,
   // Performance analysis
   enablePerf: Boolean = true,
   // RollingDB

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -73,6 +73,10 @@ class RequestArb(implicit p: Parameters) extends L2Module
 
     /* MSHR Status */
     val msInfo = Vec(mshrsAll, Flipped(ValidIO(new MSHRInfo())))
+
+    /*l2 Flush */
+    val cmoAllBlock = Option.when(cacheParams.enableL2Flush) (Input(Bool())) // To block sinkC when l2 flush
+
   })
 
   /* ======== Reset ======== */
@@ -125,11 +129,11 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val B_task = io.sinkB.bits
   val C_task = io.sinkC.bits
   val block_A = io.fromMSHRCtl.blockA_s1 || io.fromMainPipe.blockA_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockA_s1
-  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1 ||
+  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1
     (if (io.fromSourceC.isDefined) io.fromSourceC.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXDAT.isDefined) io.fromTXDAT.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXRSP.isDefined) io.fromTXRSP.get.blockSinkBReqEntrance else false.B)
-  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1
+  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1 || io.cmoAllBlock.getOrElse(false.B)
 
 //  val noFreeWay = Wire(Bool())
 
@@ -176,6 +180,8 @@ class RequestArb(implicit p: Parameters) extends L2Module
   io.dirRead_s1.bits.replacerInfo.refill_prefetch := s1_needs_replRead && (mshr_task_s1.bits.opcode === HintAck && mshr_task_s1.bits.dsWen)
   io.dirRead_s1.bits.refill := s1_needs_replRead
   io.dirRead_s1.bits.mshrId := task_s1.bits.mshrId
+  io.dirRead_s1.bits.cmoAll := task_s1.bits.cmoAll
+  io.dirRead_s1.bits.cmoWay := task_s1.bits.way
 
   // block same-set A req
   io.s1Entrance.valid := mshr_task_s1.valid && s2_ready && mshr_task_s1.bits.metaWen || io.sinkC.fire || io.sinkB.fire

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -32,10 +32,23 @@ class SinkA(implicit p: Parameters) extends L2Module {
     val a = Flipped(DecoupledIO(new TLBundleA(edgeIn.bundle)))
     val prefetchReq = prefetchOpt.map(_ => Flipped(DecoupledIO(new PrefetchReq)))
     val task = DecoupledIO(new TaskBundle)
+    val cmoAll = Option.when(cacheParams.enableL2Flush) (new IOCMOAll)
   })
   assert(!(io.a.valid && (io.a.bits.opcode === PutFullData ||
                           io.a.bits.opcode === PutPartialData)),
     "no Put");
+
+  // flush L2 all control defines
+  val numSets = 1 << setBits 
+  val numWays = 1 << wayBits
+  val set = RegInit(0.U(setBits.W))
+  val way = RegInit(0.U(wayBits.W)) 
+  val sIDLE :: sCMOREQ :: sWAITLINE :: sWAITMSHR :: sDONE :: Nil = Enum(5)
+  val state = RegInit(sIDLE)
+  val cmoAllValid = (state === sCMOREQ)
+  val cmoAllBlock = (state === sCMOREQ) || (state === sWAITLINE)
+  io.cmoAll.foreach {cmoAll => cmoAll.l2FlushDone :=(state ===sDONE)}
+  io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := cmoAllBlock}
 
   def fromTLAtoTaskBundle(a: TLBundleA): TaskBundle = {
     val task = Wire(new TaskBundle)
@@ -43,10 +56,10 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.channel := "b001".U
     task.txChannel := 0.U
     task.tag := parseAddress(a.address)._1
-    task.set := parseAddress(a.address)._2
+    task.set := Mux(cmoAllValid, set, parseAddress(a.address)._2)
     task.off := parseAddress(a.address)._3
     task.alias.foreach(_ := a.user.lift(AliasKey).getOrElse(0.U))
-    task.opcode := a.opcode
+    task.opcode := Mux(cmoAllValid, 13.U, a.opcode)
     task.param := a.param
     task.size := a.size
     task.sourceId := a.source
@@ -61,7 +74,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
-    task.way := 0.U(wayBits.W)
+    task.way := Mux(cmoAllValid, way, 0.U(wayBits.W))
     task.meta := 0.U.asTypeOf(new MetaEntry)
     task.metaWen := false.B
     task.tagWen := false.B
@@ -74,6 +87,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.isKeyword.foreach(_ := a.echo.lift(IsKeywordKey).getOrElse(false.B))
     task.mergeA := false.B
     task.aMergeTask := 0.U.asTypeOf(new MergeTaskBundle)
+    task.cmoAll := cmoAllValid
     task
   }
   def fromPrefetchReqtoTaskBundle(req: PrefetchReq): TaskBundle = {
@@ -115,19 +129,63 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task
   }
   if (prefetchOpt.nonEmpty) {
-    io.task.valid := io.a.valid || io.prefetchReq.get.valid
+    io.task.valid := io.a.valid && !cmoAllBlock || io.prefetchReq.get.valid || cmoAllValid
     io.task.bits := Mux(
-      io.a.valid,
+      io.a.valid || cmoAllValid,
       fromTLAtoTaskBundle(io.a.bits),
       fromPrefetchReqtoTaskBundle(io.prefetchReq.get.bits
     ))
-
-    io.a.ready := io.task.ready
+    io.a.ready := io.task.ready && !cmoAllBlock
     io.prefetchReq.get.ready := io.task.ready && !io.a.valid
   } else {
-    io.task.valid := io.a.valid
-    io.task.bits := fromTLAtoTaskBundle(io.a.bits)
-    io.a.ready := io.task.ready
+    io.task.valid := io.a.valid && !cmoAllBlock || cmoAllValid
+    io.task.bits := fromTLAtoTaskBundle(io.a.bits) 
+    io.a.ready := io.task.ready && !cmoAllBlock
+  }
+
+  /*
+   Flush L2 All means search all L2$ VALID cacheLine and RELEASE to Downwords memory:
+   -------------------------------------------------------------------------------------------------------
+          Step by Step                                                   |    Interface 
+   ----------------------------------------------------------------------|--------------------------------
+   0. Core initiate flush L2$ All operation                              |  io.cmoAll.l2Flush 
+   1. wait all mshrs done, block sinkA/C by ready until l2 flush done    |  io.cmoAll.cmoAllBlock 
+   2. search all cacheline set with a loop (0 ~ numSets)                 |  io.task.set
+   3. for each set, search all ways with a loop (0 ~ numWays)            |  io.task.way
+   4. if cacheline is VALID, after cmo flush, Mainpipe send back resp    |  io.cmoAll.cmoLineDone
+   5. if cacheline is INVALID, MainPipe drop it and send back resp       |  io.cmoAll.cmoLineDone
+   6. after all slices is flushed, inform Core                           |  io.cmoAll.l2FlushDone 
+   7. after all slices is flushed, exit coherency                        |  TL2CHICoupledL2.io_chi.syscoreq
+   ---------------------------------------------------------------------------------------------------------*/
+  val l2Flush = io.cmoAll.map(_.l2Flush).getOrElse(false.B)
+  val mshrValid = io.cmoAll.map(_.mshrValid).getOrElse(false.B)
+  val cmoLineDone = io.cmoAll.map(_.cmoLineDone).getOrElse(false.B)
+
+  when (state === sIDLE && l2Flush && !mshrValid) {
+    state := sCMOREQ
+  }
+  when ((state === sCMOREQ) && io.task.fire) {
+    state := sWAITLINE
+  }
+  when (state === sWAITLINE && cmoLineDone) {
+    when (set===(numSets-1).U && way===(numWays-1).U) { 
+      state := sDONE
+    }.otherwise {
+      when(way ===(numWays -1).U) {
+        way:=0.U
+        set:=set+1.U
+      }.otherwise {
+        way:=way+1.U
+      }
+      when (mshrValid) {
+        state := sCMOREQ
+      }.otherwise {
+        state := sWAITMSHR
+      }
+    }
+  }
+  when ((state === sWAITMSHR) && !mshrValid) {
+    state := sCMOREQ
   }
 
   // Performance counters

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -255,6 +255,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         rxdat <> linkMonitor.io.in.rx.dat
         io_chi <> linkMonitor.io.out
         linkMonitor.io.nodeID := io_nodeID
+        linkMonitor.io.exitco.foreach{_ := Cat(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone.getOrElse(false.B)}).andR} //exit coherency
     }
   }
 

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -277,6 +277,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     val in = Flipped(new DecoupledPortIO())
     val out = new PortIO
     val nodeID = Input(UInt(NODEID_WIDTH.W))
+    val exitco = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
   })
   // val s_stop :: s_activate :: s_run :: s_deactivate :: Nil = Enum(4)
 
@@ -308,8 +309,9 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
     init = false.B
   )
-
-  io.out.syscoreq := true.B
+  //exit coherecy + deactive tx/rx when l2 flush done
+  val exitco = io.exitco.getOrElse(false.B)
+  io.out.syscoreq := !exitco
 
   val retryAckCnt = RegInit(0.U(64.W))
   val pCrdGrantCnt = RegInit(0.U(64.W))

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -171,6 +171,12 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   refillUnit.io.sinkD <> outBuf.d(io.out.d)
   io.out.e <> outBuf.e(refillUnit.io.sourceE)
 
+  /* tie cmo All channels */
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := false.B}
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := false.B}
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := false.B}
+  mainPipe.io.cmoAllBlock.foreach {_ := false.B}
+
   dontTouch(io.in)
   dontTouch(io.out)
 


### PR DESCRIPTION
feat(TL2CIHCoupledL2): add flush L2 all operation to search all VALID cacheline to release to memory
  * Core initiate flush L2$ all operation by core and L2 interface <io.l2Flush>
  * The Barrier is added to wait all mshrs done before l2 flush begin
  * The FSM in SinkA is added to insert 'CBO_FLUSH' with set/way task to main pipe
  * The set/way are generated by the set loop(0~numSets) and way loop(0~numWays)
  * If cache line is VALID, after cbo flush, main pipe send back resp to sinkA
  * if cache line is INVALID, main pipe drop it and send back resp to sinkA
  * During the process, sinkA/C is blocked by ready until l2 flush done
  * Snoop operations from sinkB is allowed to enter into mainPipe
  * After all slices done, inform Core and exit coherency