### PR TITLE
 feat(CoupledL2): add flush L2 all operation

### DIFF
--- a/src/main/scala/coupledL2/BaseSlice.scala
+++ b/src/main/scala/coupledL2/BaseSlice.scala
@@ -37,6 +37,8 @@ abstract class BaseSliceIO[T_OUT <: BaseOuterBundle](implicit p: Parameters) ext
   val latePF = topDownOpt.map(_ => Output(Bool()))
   val error = DecoupledIO(new L2CacheErrorInfo())
   val l2Miss = Output(Bool())
+  val l2Flush = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
+  val l2FlushDone = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
 }
 
 abstract class BaseSlice[T_OUT <: BaseOuterBundle](implicit p: Parameters) extends L2Module with HasPerfEvents {

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -108,6 +108,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   // for CMO
   val cmoTask = Bool()
+  val cmoAll = Bool()
 
   // for TopDown Monitor (# TopDown)
   val reqSource = UInt(MemReqSource.reqSourceBits.W)
@@ -456,4 +457,12 @@ class PCrdGrantMatcher(val numPorts: Int) extends Module {
 class L2CacheErrorInfo(implicit p: Parameters) extends L2Bundle {
   val valid = Bool()
   val address = UInt(addressBits.W)
+}
+class IOCMOAll(implicit p: Parameters) extends Bundle {
+  val l2Flush = Input(Bool())
+  val l2FlushDone = Output(Bool())
+
+  val cmoLineDone = Input(Bool())
+  val mshrValid = Input(Bool())
+  val cmoAllBlock = Output(Bool())
 }

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -458,11 +458,12 @@ class L2CacheErrorInfo(implicit p: Parameters) extends L2Bundle {
   val valid = Bool()
   val address = UInt(addressBits.W)
 }
-class IOCMOAll(implicit p: Parameters) extends Bundle {
-  val l2Flush = Input(Bool())
-  val l2FlushDone = Output(Bool())
 
-  val cmoLineDone = Input(Bool())
-  val mshrValid = Input(Bool())
-  val cmoAllBlock = Output(Bool())
+class IOCMOAll(implicit p: Parameters) extends Bundle {
+  val l2Flush = Input(Bool())      // cmo flush l2$ all enable
+  val l2FlushDone = Output(Bool()) // cmo flush l2$ all done 
+
+  val cmoLineDone = Input(Bool())  // during process of cmo flush all, flush 1 CacheLine is done 
+  val mshrValid = Input(Bool())    // 1: mshr has entry valid  0: no mshr entry valid
+  val cmoAllBlock = Output(Bool()) // 1: in process of cmo flush all  0: not in process of cmo flush all
 }

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -107,8 +107,8 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val replTask = Bool()
 
   // for CMO
-  val cmoTask = Bool()
-  val cmoAll = Bool()
+  val cmoTask = Bool() // cmo with address
+  val cmoAll = Bool()  // cmo without address but to flush whole L2$ to memory 
 
   // for TopDown Monitor (# TopDown)
   val reqSource = UInt(MemReqSource.reqSourceBits.W)

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -75,6 +75,9 @@ class DirRead(implicit p: Parameters) extends L2Bundle {
   // dirRead when refill
   val refill = Bool()
   val mshrId = UInt(mshrBits.W)
+  // when flush l2
+  val cmoAll = Bool()
+  val cmoWay = UInt(wayBits.W) 
 }
 
 class DirResult(implicit p: Parameters) extends L2Bundle {
@@ -260,15 +263,14 @@ class Directory(implicit p: Parameters) extends L2Module {
     chosenWay,
     PriorityEncoder(freeWayMask_s3)
   )
-
-  val hit_s3 = Cat(hitVec).orR
-  val way_s3 = Mux(hit_s3, hitWay, finalWay)
+  val hit_s3 = Cat(hitVec).orR || req_s3.cmoAll
+  val way_s3 = Mux(req_s3.cmoAll, req_s3.cmoWay, Mux(hit_s3, hitWay, finalWay))
   val meta_s3 = metaAll_s3(way_s3)
   val tag_s3 = tagAll_s3(way_s3)(tagBits - 1, 0)
   val set_s3 = req_s3.set
   val replacerInfo_s3 = req_s3.replacerInfo
   val error_s3 = if (enableTagECC) {
-    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && meta_s3.state =/= MetaData.INVALID
+    cacheParams.tagCode.decode(tagAll_s3(way_s3)).error && reqValid_s3 && !req_s3.cmoAll && meta_s3.state =/= MetaData.INVALID
   } else {
     false.B
   }

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -100,7 +100,7 @@ case class L2Param(
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
   // L2 Flush
-  enableL2Flush: Boolean = true,
+  enableL2Flush: Boolean = false,
   // Performance analysis
   enablePerf: Boolean = true,
   // RollingDB

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -99,6 +99,8 @@ case class L2Param(
   hartId: Int = 0,
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
+  // L2 Flush
+  enableL2Flush: Boolean = true,
   // Performance analysis
   enablePerf: Boolean = true,
   // RollingDB

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -73,6 +73,10 @@ class RequestArb(implicit p: Parameters) extends L2Module
 
     /* MSHR Status */
     val msInfo = Vec(mshrsAll, Flipped(ValidIO(new MSHRInfo())))
+
+    /*l2 Flush */
+    val cmoAllBlock = Option.when(cacheParams.enableL2Flush) (Input(Bool())) // To block sinkC when l2 flush
+
   })
 
   /* ======== Reset ======== */
@@ -125,11 +129,11 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val B_task = io.sinkB.bits
   val C_task = io.sinkC.bits
   val block_A = io.fromMSHRCtl.blockA_s1 || io.fromMainPipe.blockA_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockA_s1
-  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1 ||
+  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1
     (if (io.fromSourceC.isDefined) io.fromSourceC.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXDAT.isDefined) io.fromTXDAT.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXRSP.isDefined) io.fromTXRSP.get.blockSinkBReqEntrance else false.B)
-  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1
+  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1 || io.cmoAllBlock.getOrElse(false.B)
 
 //  val noFreeWay = Wire(Bool())
 
@@ -176,6 +180,8 @@ class RequestArb(implicit p: Parameters) extends L2Module
   io.dirRead_s1.bits.replacerInfo.refill_prefetch := s1_needs_replRead && (mshr_task_s1.bits.opcode === HintAck && mshr_task_s1.bits.dsWen)
   io.dirRead_s1.bits.refill := s1_needs_replRead
   io.dirRead_s1.bits.mshrId := task_s1.bits.mshrId
+  io.dirRead_s1.bits.cmoAll := task_s1.bits.cmoAll
+  io.dirRead_s1.bits.cmoWay := task_s1.bits.way
 
   // block same-set A req
   io.s1Entrance.valid := mshr_task_s1.valid && s2_ready && mshr_task_s1.bits.metaWen || io.sinkC.fire || io.sinkB.fire

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -73,10 +73,6 @@ class RequestArb(implicit p: Parameters) extends L2Module
 
     /* MSHR Status */
     val msInfo = Vec(mshrsAll, Flipped(ValidIO(new MSHRInfo())))
-
-    /*l2 Flush */
-    val cmoAllBlock = Option.when(cacheParams.enableL2Flush) (Input(Bool())) // To block sinkC when l2 flush
-
   })
 
   /* ======== Reset ======== */
@@ -129,11 +125,11 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val B_task = io.sinkB.bits
   val C_task = io.sinkC.bits
   val block_A = io.fromMSHRCtl.blockA_s1 || io.fromMainPipe.blockA_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockA_s1
-  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1
+  val block_B = io.fromMSHRCtl.blockB_s1 || io.fromMainPipe.blockB_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockB_s1 ||
     (if (io.fromSourceC.isDefined) io.fromSourceC.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXDAT.isDefined) io.fromTXDAT.get.blockSinkBReqEntrance else false.B) ||
     (if (io.fromTXRSP.isDefined) io.fromTXRSP.get.blockSinkBReqEntrance else false.B)
-  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1 || io.cmoAllBlock.getOrElse(false.B)
+  val block_C = io.fromMSHRCtl.blockC_s1 || io.fromMainPipe.blockC_s1 || io.fromGrantBuffer.blockSinkReqEntrance.blockC_s1
 
 //  val noFreeWay = Wire(Bool())
 

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -39,8 +39,6 @@ class SinkA(implicit p: Parameters) extends L2Module {
     "no Put");
 
   // flush L2 all control defines
-  val numSets = 1 << log2Ceil(cacheParams.sets) 
-  val numWays = 1 << log2Ceil(cacheParams.ways)
   val set = Option.when(cacheParams.enableL2Flush)(RegInit(0.U(setBits.W))) 
   val way = Option.when(cacheParams.enableL2Flush)(RegInit(0.U(wayBits.W))) 
   val sIDLE :: sCMOREQ :: sWAITLINE :: sWAITMSHR :: sDONE :: Nil = Enum(5)
@@ -50,7 +48,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
   val wayVal = way.getOrElse(0.U)
   val cmoAllValid = stateVal === sCMOREQ
   val cmoAllBlock = stateVal === sCMOREQ || stateVal === sWAITLINE
-  io.cmoAll.foreach { cmoAll => cmoAll.l2FlushDone := stateVal ===sDONE }
+  io.cmoAll.foreach { cmoAll => cmoAll.l2FlushDone := stateVal === sDONE }
   io.cmoAll.foreach { cmoAll => cmoAll.cmoAllBlock := cmoAllBlock }
 
   def fromTLAtoTaskBundle(a: TLBundleA): TaskBundle = {
@@ -171,10 +169,10 @@ class SinkA(implicit p: Parameters) extends L2Module {
     state.foreach { _ := sWAITLINE }
   }
   when (stateVal === sWAITLINE && cmoLineDone) {
-    when (setVal === (numSets-1).U && wayVal === (numWays-1).U) { 
+    when (setVal === (cacheParams.sets-1).U && wayVal === (cacheParams.ways-1).U) { 
       state.foreach { _ := sDONE }
     }.otherwise {
-      when (wayVal === (numWays-1).U) {
+      when (wayVal === (cacheParams.ways-1).U) {
         way.foreach { _ := 0.U }
         set.foreach { _ := setVal + 1.U }
       }.otherwise {

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -32,10 +32,23 @@ class SinkA(implicit p: Parameters) extends L2Module {
     val a = Flipped(DecoupledIO(new TLBundleA(edgeIn.bundle)))
     val prefetchReq = prefetchOpt.map(_ => Flipped(DecoupledIO(new PrefetchReq)))
     val task = DecoupledIO(new TaskBundle)
+    val cmoAll = Option.when(cacheParams.enableL2Flush) (new IOCMOAll)
   })
   assert(!(io.a.valid && (io.a.bits.opcode === PutFullData ||
                           io.a.bits.opcode === PutPartialData)),
     "no Put");
+
+  // flush L2 all control defines
+  val numSets = 1 << setBits 
+  val numWays = 1 << wayBits
+  val set = RegInit(0.U(setBits.W))
+  val way = RegInit(0.U(wayBits.W)) 
+  val sIDLE :: sCMOREQ :: sWAITLINE :: sWAITMSHR :: sDONE :: Nil = Enum(5)
+  val state = RegInit(sIDLE)
+  val cmoAllValid = (state === sCMOREQ)
+  val cmoAllBlock = (state === sCMOREQ) || (state === sWAITLINE)
+  io.cmoAll.foreach {cmoAll => cmoAll.l2FlushDone :=(state ===sDONE)}
+  io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := cmoAllBlock}
 
   def fromTLAtoTaskBundle(a: TLBundleA): TaskBundle = {
     val task = Wire(new TaskBundle)
@@ -43,10 +56,10 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.channel := "b001".U
     task.txChannel := 0.U
     task.tag := parseAddress(a.address)._1
-    task.set := parseAddress(a.address)._2
+    task.set := Mux(cmoAllValid, set, parseAddress(a.address)._2)
     task.off := parseAddress(a.address)._3
     task.alias.foreach(_ := a.user.lift(AliasKey).getOrElse(0.U))
-    task.opcode := a.opcode
+    task.opcode := Mux(cmoAllValid, 13.U, a.opcode)
     task.param := a.param
     task.size := a.size
     task.sourceId := a.source
@@ -61,7 +74,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
-    task.way := 0.U(wayBits.W)
+    task.way := Mux(cmoAllValid, way, 0.U(wayBits.W))
     task.meta := 0.U.asTypeOf(new MetaEntry)
     task.metaWen := false.B
     task.tagWen := false.B
@@ -74,6 +87,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.isKeyword.foreach(_ := a.echo.lift(IsKeywordKey).getOrElse(false.B))
     task.mergeA := false.B
     task.aMergeTask := 0.U.asTypeOf(new MergeTaskBundle)
+    task.cmoAll := cmoAllValid
     task
   }
   def fromPrefetchReqtoTaskBundle(req: PrefetchReq): TaskBundle = {
@@ -115,19 +129,63 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task
   }
   if (prefetchOpt.nonEmpty) {
-    io.task.valid := io.a.valid || io.prefetchReq.get.valid
+    io.task.valid := io.a.valid && !cmoAllBlock || io.prefetchReq.get.valid || cmoAllValid
     io.task.bits := Mux(
-      io.a.valid,
+      io.a.valid || cmoAllValid,
       fromTLAtoTaskBundle(io.a.bits),
       fromPrefetchReqtoTaskBundle(io.prefetchReq.get.bits
     ))
-
-    io.a.ready := io.task.ready
+    io.a.ready := io.task.ready && !cmoAllBlock
     io.prefetchReq.get.ready := io.task.ready && !io.a.valid
   } else {
-    io.task.valid := io.a.valid
-    io.task.bits := fromTLAtoTaskBundle(io.a.bits)
-    io.a.ready := io.task.ready
+    io.task.valid := io.a.valid && !cmoAllBlock || cmoAllValid
+    io.task.bits := fromTLAtoTaskBundle(io.a.bits) 
+    io.a.ready := io.task.ready && !cmoAllBlock
+  }
+
+  /*
+   Flush L2 All means search all L2$ VALID cacheLine and RELEASE to Downwords memory:
+   -------------------------------------------------------------------------------------------------------
+          Step by Step                                                   |    Interface 
+   ----------------------------------------------------------------------|--------------------------------
+   0. Core initiate flush L2$ All operation                              |  io.cmoAll.l2Flush 
+   1. wait all mshrs done, block sinkA/C by ready until l2 flush done    |  io.cmoAll.cmoAllBlock 
+   2. search all cacheline set with a loop (0 ~ numSets)                 |  io.task.set
+   3. for each set, search all ways with a loop (0 ~ numWays)            |  io.task.way
+   4. if cacheline is VALID, after cmo flush, Mainpipe send back resp    |  io.cmoAll.cmoLineDone
+   5. if cacheline is INVALID, MainPipe drop it and send back resp       |  io.cmoAll.cmoLineDone
+   6. after all slices is flushed, inform Core                           |  io.cmoAll.l2FlushDone 
+   7. after all slices is flushed, exit coherency                        |  TL2CHICoupledL2.io_chi.syscoreq
+   ---------------------------------------------------------------------------------------------------------*/
+  val l2Flush = io.cmoAll.map(_.l2Flush).getOrElse(false.B)
+  val mshrValid = io.cmoAll.map(_.mshrValid).getOrElse(false.B)
+  val cmoLineDone = io.cmoAll.map(_.cmoLineDone).getOrElse(false.B)
+
+  when (state === sIDLE && l2Flush && !mshrValid) {
+    state := sCMOREQ
+  }
+  when ((state === sCMOREQ) && io.task.fire) {
+    state := sWAITLINE
+  }
+  when (state === sWAITLINE && cmoLineDone) {
+    when (set===(numSets-1).U && way===(numWays-1).U) { 
+      state := sDONE
+    }.otherwise {
+      when(way ===(numWays -1).U) {
+        way:=0.U
+        set:=set+1.U
+      }.otherwise {
+        way:=way+1.U
+      }
+      when (mshrValid) {
+        state := sCMOREQ
+      }.otherwise {
+        state := sWAITMSHR
+      }
+    }
+  }
+  when ((state === sWAITMSHR) && !mshrValid) {
+    state := sCMOREQ
   }
 
   // Performance counters

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -378,25 +378,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       }
     }
     when (req_s3.chiOpcode.get === SnpCleanShared) {
-<<<<<<< HEAD
       respCacheState := Mux(isT(nestable_meta_s3.state), UC, SC)
-=======
-      respCacheState := Mux(meta_s3.state === BRANCH, SC, UC)
-    }
-  }
-
-  when (req_s3.snpHitRelease) {
-    /**
-      * NOTICE: On Stash and Query:
-      * the cache state must maintain unchanged on nested copy-back writes
-     */
-    when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
-      respCacheState := Mux(
-        req_s3.snpHitReleaseState === BRANCH,
-        SC,
-        Mux(req_s3.snpHitReleaseDirty, UD, UC)
-      )
->>>>>>> a376cec (feat(TL2CIHCoupledL2): add flush L2 all operation to search all VALID cacheline to release to memory)
     }
   }
 
@@ -676,7 +658,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   /* ======== nested writeback ======== */
   io.nestedwb.set := req_s3.set
-  io.nestedwb.tag := req_s3.tag
+  io.netedwb.tag := req_s3.tag
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData && task_s3.bits.param === TtoN

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -156,6 +156,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val sinkA_req_s3    = !mshr_req_s3 && req_s3.fromA
   val sinkB_req_s3    = !mshr_req_s3 && req_s3.fromB
   val sinkC_req_s3    = !mshr_req_s3 && req_s3.fromC
+  val cmoHitInvalid   = io.cmoAllBlock.getOrElse(false.B) && (meta_s3.state === INVALID)
 
   val req_acquire_s3            = sinkA_req_s3 && (req_s3.opcode === AcquireBlock || req_s3.opcode === AcquirePerm)
   val req_acquireBlock_s3       = sinkA_req_s3 && req_s3.opcode === AcquireBlock
@@ -195,7 +196,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   val cmo_cbo_retention_s3      = req_cbo_clean_s3 || req_cbo_flush_s3
   val cmo_cbo_s3                = req_cbo_clean_s3 || req_cbo_flush_s3 || req_cbo_inval_s3
-  val cmoHitInvalid             = io.cmoAllBlock.getOrElse(false.B) && (meta_s3.state === INVALID)
 
   val cache_alias               = req_acquire_s3 && dirResult_s3.hit && meta_s3.clients(0) &&
                               meta_s3.alias.getOrElse(0.U) =/= req_s3.alias.getOrElse(0.U)

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -156,7 +156,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val sinkA_req_s3    = !mshr_req_s3 && req_s3.fromA
   val sinkB_req_s3    = !mshr_req_s3 && req_s3.fromB
   val sinkC_req_s3    = !mshr_req_s3 && req_s3.fromC
-  val cmoHitInvalid   = io.cmoAllBlock.getOrElse(false.B) && (meta_s3.state === INVALID)
 
   val req_acquire_s3            = sinkA_req_s3 && (req_s3.opcode === AcquireBlock || req_s3.opcode === AcquirePerm)
   val req_acquireBlock_s3       = sinkA_req_s3 && req_s3.opcode === AcquireBlock
@@ -658,7 +657,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   /* ======== nested writeback ======== */
   io.nestedwb.set := req_s3.set
-  io.netedwb.tag := req_s3.tag
+  io.nestedwb.tag := req_s3.tag
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData && task_s3.bits.param === TtoN

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -388,7 +388,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   when (req_s3.snpHitRelease) {
     /**
       * NOTICE: On Stash and Query:
-      * the cache state must maintain unchanged on nested WriteBack
+      * the cache state must maintain unchanged on nested copy-back writes
      */
     when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -112,6 +112,10 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
     /* ECC error*/
     val error = ValidIO(new L2CacheErrorInfo)
+
+    /* l2 flush (CMO All) */
+    val cmoAllBlock = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
+    val cmoLineDone = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
   })
 
   require(chiOpt.isDefined)
@@ -145,6 +149,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val dirResult_s3    = io.dirResp_s3
   val meta_s3         = dirResult_s3.meta
   val req_s3          = task_s3.bits
+  val cmoHitInvalid   = io.cmoAllBlock.getOrElse(false.B) && (meta_s3.state === INVALID)
 
   val mshr_req_s3     = req_s3.mshrTask
   val sink_req_s3     = !mshr_req_s3
@@ -157,7 +162,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val req_prefetch_s3           = sinkA_req_s3 && req_s3.opcode === Hint
   val req_get_s3                = sinkA_req_s3 && req_s3.opcode === Get
   val req_cbo_clean_s3          = sinkA_req_s3 && req_s3.opcode === CBOClean
-  val req_cbo_flush_s3          = sinkA_req_s3 && req_s3.opcode === CBOFlush
+  val req_cbo_flush_s3          = sinkA_req_s3 && req_s3.opcode === CBOFlush && !cmoHitInvalid
   val req_cbo_inval_s3          = sinkA_req_s3 && req_s3.opcode === CBOInval
 
   val mshr_grant_s3             = mshr_req_s3 && req_s3.fromA && (req_s3.opcode === Grant || req_s3.opcode === GrantData)
@@ -607,12 +612,12 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val txdat_s3_latch = true
   val isD_s3 = Mux(
     mshr_req_s3,
-    mshr_cmoresp_s3 || mshr_refill_s3 && !retry,
-    req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint
+    mshr_cmoresp_s3 && !io.cmoAllBlock.getOrElse(false.B) || mshr_refill_s3 && !retry,
+    req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint && !io.cmoAllBlock.getOrElse(false.B)
   )
   val isD_s3_ready = Mux(
     mshr_req_s3,
-    mshr_cmoresp_s3 || mshr_refill_s3 && !retry,
+    mshr_cmoresp_s3 && !io.cmoAllBlock.getOrElse(false.B) || mshr_refill_s3 && !retry,
     req_s3.fromC || req_s3.fromA && !need_mshr_s3_a && !data_unready_s3_tl && req_s3.opcode =/= Hint && !d_s3_latch.B
   )
   val isTXRSP_s3 = Mux(
@@ -959,6 +964,14 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.error.valid := task_s5.valid
   io.error.bits.valid := l2Error_s5 // if not enableECC, should be false
   io.error.bits.address := Cat(task_s5.bits.tag, task_s5.bits.set, task_s5.bits.off)
+
+  /* CMO All Flush cacheline done if:
+   cacheline is INVALID -> drop @s3
+   cacheline is VALID send back resp when mshr complete CBOFlush flow with mshr_comresp_s3 @s3
+   */
+  val cmoLineDrop = task_s3.valid && sinkA_req_s3 && req_s3.opcode === CBOFlush && cmoHitInvalid
+  val cmoLineDone = io.cmoAllBlock.getOrElse(false.B) && task_s3.valid && mshr_cmoresp_s3
+  io.cmoLineDone.foreach { _ := RegNextN(cmoLineDone || cmoLineDrop, 2, Some(false.B)) }
 
   /* ===== Performance counters ===== */
   // num of mshr req

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -972,7 +972,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val cmoLineDrop = task_s3.valid && sinkA_req_s3 && req_s3.opcode === CBOFlush && cmoHitInvalid
   val cmoLineDone = io.cmoAllBlock.getOrElse(false.B) && task_s3.valid && mshr_cmoresp_s3
   io.cmoLineDone.foreach { _ := RegNextN(cmoLineDone || cmoLineDrop, 2, Some(false.B)) }
-
   /* ===== Performance counters ===== */
   // num of mshr req
   XSPerfAccumulate("mshr_grant_req", task_s3.valid && mshr_grant_s3 && !retry)

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -92,8 +92,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
 
   reqArb.io.ATag := reqBuf.io.ATag
   reqArb.io.ASet := reqBuf.io.ASet
-  //  reqArb.io.cmoAllBlock := sinkA.io.cmoAll.cmoAllBlock
-  reqArb.io.cmoAllBlock.foreach{_ := sinkA.io.cmoAll.map(_.cmoAllBlock).getOrElse(false.B)}
   reqArb.io.sinkA <> reqBuf.io.out
   reqArb.io.sinkB <> rxsnp.io.task
   reqArb.io.sinkC <> sinkC.io.task

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -255,6 +255,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         rxdat <> linkMonitor.io.in.rx.dat
         io_chi <> linkMonitor.io.out
         linkMonitor.io.nodeID := io_nodeID
+        linkMonitor.io.exitco.foreach{_ := Cat(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone.getOrElse(false.B)}).andR} //exit coherency
     }
   }
 

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -277,6 +277,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     val in = Flipped(new DecoupledPortIO())
     val out = new PortIO
     val nodeID = Input(UInt(NODEID_WIDTH.W))
+    val exitco = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
   })
   // val s_stop :: s_activate :: s_run :: s_deactivate :: Nil = Enum(4)
 
@@ -308,8 +309,9 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
     init = false.B
   )
-
-  io.out.syscoreq := true.B
+  //exit coherecy + deactive tx/rx when l2 flush done
+  val exitco = io.exitco.getOrElse(false.B)
+  io.out.syscoreq := !exitco
 
   val retryAckCnt = RegInit(0.U(64.W))
   val pCrdGrantCnt = RegInit(0.U(64.W))

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -247,7 +247,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.snpHitReleaseMeta := MetaEntry()
   ms_task.denied           := false.B
   ms_task.corrupt          := false.B
-
+  ms_task.cmoAll           := false.B
   /* ======== Resps to SinkA/B/C Reqs ======== */
   val sink_resp_s3 = WireInit(0.U.asTypeOf(Valid(new TaskBundle))) // resp for sinkA/B/C request that does not need to alloc mshr
   val sink_resp_s3_a_promoteT = dirResult_s3.hit && isT(meta_s3.state)

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -175,7 +175,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := false.B}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := false.B}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := false.B}
-  mainPipe.io.cmoAllBlock.foreach {_ := false.B}
 
   dontTouch(io.in)
   dontTouch(io.out)

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -67,7 +67,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   reqArb.io.sinkA <> a_reqBuf.io.out
   reqArb.io.ATag := a_reqBuf.io.ATag
   reqArb.io.ASet := a_reqBuf.io.ASet
-  reqArb.io.cmoAllBlock.foreach{_ := false.B}
 
   reqArb.io.sinkB <> sinkB.io.task
   reqArb.io.sinkC <> sinkC.io.task

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -67,6 +67,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   reqArb.io.sinkA <> a_reqBuf.io.out
   reqArb.io.ATag := a_reqBuf.io.ATag
   reqArb.io.ASet := a_reqBuf.io.ASet
+  reqArb.io.cmoAllBlock.foreach{_ := false.B}
 
   reqArb.io.sinkB <> sinkB.io.task
   reqArb.io.sinkC <> sinkC.io.task
@@ -175,6 +176,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := false.B}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoLineDone := false.B}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := false.B}
+
+  io.l2FlushDone.foreach {_ := false.B}
 
   dontTouch(io.in)
   dontTouch(io.out)

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -173,7 +173,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
 
   /* tie cmo All channels */
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := false.B}
-  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := false.B}
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoLineDone := false.B}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := false.B}
 
   dontTouch(io.in)

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -171,6 +171,12 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   refillUnit.io.sinkD <> outBuf.d(io.out.d)
   io.out.e <> outBuf.e(refillUnit.io.sourceE)
 
+  /* tie cmo All channels */
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := false.B}
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.cmoAllBlock := false.B}
+  sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := false.B}
+  mainPipe.io.cmoAllBlock.foreach {_ := false.B}
+
   dontTouch(io.in)
   dontTouch(io.out)
 


### PR DESCRIPTION
      * Core initiate flush L2$ all operation by core and L2 interface <io.l2Flush>
      * The Barrier is added to wait all mshrs done before l2 flush begin
      * The FSM in SinkA is added to insert 'CBO_FLUSH' with set/way task to main pipe
      * The set/way are generated by the set loop（0~numSets） and way loop（0~numWays）
      * If cache-line is VALID, after CBO flush, main pipe sends back resp to SinkA
      * if cache-line is INVALID, main pipe drop it and send back resp to SinkA
      * Snoop operations from SinkB is allowed to enter into main pipe
      * After all slices done, inform Core and exit coherency
      * fix tl2tl version with invalid <io.l2Flush>
      * Align code to the coding style
