### PR TITLE
fix(MSHR): keep scheduled CopyBackWrData on nested retry

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -999,9 +999,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       state.s_reissue.get := true.B
       gotRetryAck := false.B
       gotPCrdGrant := false.B
-      when (release_valid2) {
-        state.s_cbwrdata.get := isEvict
-      }
     }
   }
   when (io.tasks.txrsp.fire) {


### PR DESCRIPTION
* Since the retry immutability has been guaranteed, the scheduled CopyBackWrData (```s_cbwrdata```) is no longer needed to be updated on writeback retry.