### PR TITLE
fix(MainPipe, MSHR): state transitions of nested WriteCleanFull

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -120,7 +120,8 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   // Used for get data from ReleaseBuf when snoop hit with same PA 
   val snpHitRelease = Bool()
-  val snpHitReleaseToB = Bool()
+  val snpHitReleaseToInval = Bool()
+  val snpHitReleaseToClean = Bool()
   val snpHitReleaseWithData = Bool()
   val snpHitReleaseIdx = UInt(mshrBits.W) 
   val snpHitReleaseState = UInt(2.W)
@@ -226,8 +227,8 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle with HasTLChannelBits {
 
   val replaceData = Bool() // If there is a replace, WriteBackFull or Evict
 
-  // exclude Release toB for nested snoop of releases
-  val releaseToB = Bool()
+  // release to T with data or UC (e.g. WriteCleanFull)
+  val releaseToClean = Bool()
 }
 
 class RespInfoBundle(implicit p: Parameters) extends L2Bundle

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -216,8 +216,12 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       (isSnpToBNonFwd(req_chiOpcode) || isSnpToNNonFwd(req_chiOpcode) || isSnpOnce(req_chiOpcode)) ||
     hitWriteEvict &&
        isSnpOnce(req_chiOpcode))
-  // doRespData_once includes SnpOnceFwd(nested) UD -> I and SnpOnce UC -> UC/I(non-nested/nested)
-  val doRespData_once = hitWriteBack &&
+  // doRespData_once includes 
+  //  1. SnpOnceFwd : UD -> I     (nesting WriteBack)
+  //  2. SnpOnceFwd : UD -> SC    (nesting WriteClean)
+  //  3. SnpOnce    : UC -> UC    (non-nesting)
+  //  4. SnpOnce    : UC -> I     (nesting WriteBack)
+  val doRespData_once = (hitWriteBack || hitWriteClean) &&
       isSnpOnceFwd(req_chiOpcode) ||
     (dirResult.hit && !meta.dirty && meta.state =/= BRANCH || hitWriteEvict) &&
       isSnpOnce(req_chiOpcode)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -302,7 +302,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   }
 
   // resp and fwdState
-  val respCacheState = Mux(dirResult.hit, ParallelPriorityMux(Seq(
+  val respCacheState = ParallelPriorityMux(Seq(
     snpToN -> I,
     snpToB -> SC,
     isSnpOnceX(req_chiOpcode) ->
@@ -315,7 +315,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       Mux(probeDirty || meta.dirty, UD, metaChi),
     isSnpCleanShared(req_chiOpcode) -> 
       Mux(isT(meta.state), UC, metaChi)
-  )), I)
+  ))
   val respPassDirty = hitDirtyOrWriteDirty && (
     snpToB ||
     req_chiOpcode === SnpUnique ||
@@ -647,7 +647,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         isSnpOnceX(req_chiOpcode) && req.snpHitReleaseToClean
       ) || isSnpOnceX(req_chiOpcode) && probeDirty,
       // Directory would always be missing on nesting WriteBackFull/WriteEvict*/Evict
-      state = Mux(dirResult.hit, Mux(
+      state = Mux(
         snpToN,
         INVALID,
         Mux(
@@ -655,7 +655,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
           snpToB || isSnpOnceX(req_chiOpcode) && hitWriteClean,
           BRANCH,
           meta.state)
-      ), I),
+      ),
       clients = meta.clients & Fill(clientBits, !probeGotN && !snpToN),
       alias = meta.alias, //[Alias] Keep alias bits unchanged
       prefetch = !snpToN && meta_pft,

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -302,15 +302,16 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   }
 
   // resp and fwdState
+  // *NOTICE: Snp*Fwd would enter MSHR on directory missing
   val respCacheState = ParallelPriorityMux(Seq(
     snpToN -> I,
-    snpToB -> SC,
+    snpToB -> Mux(!dirResult.hit, I, SC),
     isSnpOnceX(req_chiOpcode) ->
-      Mux(
+      Mux(!dirResult.hit, I, Mux(
         req.snpHitReleaseToClean,
         SC,
         Mux(probeDirty || meta.dirty, UD, metaChi)
-      ),
+      )),
     (isSnpStashX(req_chiOpcode) || isSnpQuery(req_chiOpcode)) ->
       Mux(probeDirty || meta.dirty, UD, metaChi),
     isSnpCleanShared(req_chiOpcode) -> 

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -502,9 +502,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   /* ======== Write Directory ======== */
   val metaW_valid_s3_a = sinkA_req_s3 && !need_mshr_s3_a && !req_get_s3 && !req_prefetch_s3 && !cmo_cbo_s3 // get & prefetch that hit will not write meta
   // Also write directory on:
-  //  1. SnpOnce/SnpOnceFwd nesting WriteCleanFull under UD/UC/SC
+  //  1. SnpOnce nesting WriteCleanFull under UD (SnpOnceFwd always needs MSHR) for UD -> SC
   val metaW_valid_s3_b = sinkB_req_s3 && !need_mshr_s3_b && dirResult_s3.hit &&
-    (!isSnpOnceX(req_s3.chiOpcode.get) || req_s3.snpHitReleaseToClean) && 
+    (!isSnpOnce(req_s3.chiOpcode.get) || (req_s3.snpHitReleaseToClean && req_s3.snpHitReleaseDirty)) && 
     !isSnpStashX(req_s3.chiOpcode.get) && !isSnpQuery(req_s3.chiOpcode.get) && (
       meta_s3.state === TIP || meta_s3.state === BRANCH && isSnpToN(req_s3.chiOpcode.get)
     )

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -329,8 +329,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       respCacheState := Mux(isT(meta_s3.state), UC, SC)
     }
 
-    when (req_s3.snpHitReleaseToClean)
-    {
+    when (req_s3.snpHitReleaseToClean) {
       // On SnpOnce/SnpOnceFwd nesting WriteCleanFull, turn UD/UC to SC
       when (isSnpOnceX(req_s3.chiOpcode.get)) {
         respCacheState := SC

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -369,6 +369,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     }
   }
 
+  val sink_resp_s3_b_meta = Wire(MetaEntry())
+  val sink_resp_s3_b_metaWen = Wire(Bool())
+
   sink_resp_s3.valid := task_s3.valid && !mshr_req_s3 && !need_mshr_s3
   sink_resp_s3.bits := task_s3.bits
   sink_resp_s3.bits.mshrId := (1 << (mshrBits-1)).U + sink_resp_s3.bits.sourceId
@@ -429,8 +432,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       false.B
     ) // TODO: parameterize this
     sink_resp_s3.bits.size := log2Ceil(blockBytes).U
-    sink_resp_s3.bits.meta := metaW_s3_b
-    sink_resp_s3.bits.metaWen := metaW_valid_s3_b
+    sink_resp_s3.bits.meta := sink_resp_s3_b_meta
+    sink_resp_s3.bits.metaWen := sink_resp_s3_b_metaWen
 
   }.otherwise { // req_s3.fromC
     sink_resp_s3.bits.opcode := ReleaseAck
@@ -582,6 +585,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.tagWReq.bits.set := req_s3.set
   io.tagWReq.bits.way := Mux(mshr_refill_s3 && req_s3.replTask, io.replResp.bits.way, req_s3.way)
   io.tagWReq.bits.wtag := req_s3.tag
+
+  sink_resp_s3_b_metaWen := metaW_valid_s3_b
+  sink_resp_s3_b_meta := metaW_s3_b
 
   /* ======== Interact with Channels (SourceD/TXREQ/TXRSP/TXDAT) ======== */
   val chnl_fire_s3 = d_s3.fire || txreq_s3.fire || txrsp_s3.fire || txdat_s3.fire

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -326,12 +326,20 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       )
     }
     when (req_s3.chiOpcode.get === SnpCleanShared) {
-      respCacheState := Mux(meta_s3.state === BRANCH, SC, UC)
+      respCacheState := Mux(isT(meta_s3.state), UC, SC)
+    }
+
+    when (req_s3.snpHitReleaseToClean)
+    {
+      // On SnpOnce/SnpOnceFwd nesting WriteCleanFull, turn UD/UC to SC
+      when (isSnpOnceX(req_s3.chiOpcode.get)) {
+        respCacheState := SC
+      }
     }
   }
 
   when (req_s3.snpHitRelease) {
-    // *NOTICE: On Stash and Query, the cache state must maintain unchanged on nested WriteBack
+    // *NOTICE: On Stash and Query, the cache state must maintain unchanged on nested copy-back writes
     when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
         req_s3.snpHitReleaseState === BRANCH,
@@ -388,8 +396,27 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       Cat(true.B, true.B)   -> SnpRespDataFwded
     )))
     sink_resp_s3.bits.resp.foreach(_ := Mux(
-      req_s3.snpHitRelease && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
-      setPD(I, req_s3.snpHitReleaseWithData && req_s3.snpHitReleaseDirty && !isSnpMakeInvalidX(req_s3.chiOpcode.get)),
+      req_s3.snpHitReleaseToInval && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
+      setPD(
+        // On directory hit under non-invalidating snoop nesting WriteCleanFull, 
+        // excluding SnpStashX and SnpQuery:
+        //  1. SnpCleanShared[1-sink_resp]  : UD -> UC_PD, UC -> UC, SC -> SC
+        //  2. SnpOnce*[2-sink_resp]        : UD -> SC_PD, UC -> SC, SC -> SC
+        //  3. snpToB                       : UD -> SC_PD, UC -> SC, SC -> SC
+        // 
+        // *NOTE[1-sink_resp]:
+        //    UD -> SC transitions were not used on WriteCleanFull without nesting snoop, and
+        //    only UD -> UC update could be observed on directory in this case
+        //    Therefore, it was unnecessary to observe cache state from nested WriteCleanFull MSHRs, while
+        //    extracting PassDirty from MSHRs
+        //
+        // *NOTE[2-sink_resp]:
+        //    UD -> UC transitions were not allowed on SnpOnce*, while permitting UD -> UD and UC -> UC
+        //    On SnpOnce*, UD/UC were turned into SC on nested WriteClean, on which directory must hit
+        //    Otherwise, the cache state was fast forwarded to I by default
+        //    Directory might be missing after multiple nesting snoops on WriteClean, indicating losing UD
+        Mux(req_s3.snpHitReleaseToClean && !isSnpToN(req_s3.chiOpcode.get), respCacheState, I),
+        req_s3.snpHitReleaseWithData && req_s3.snpHitReleaseDirty && !isSnpMakeInvalidX(req_s3.chiOpcode.get)),
       setPD(respCacheState, respPassDirty && (doRespData || doRespDataHitRelease))
     ))
     sink_resp_s3.bits.fwdState.foreach(_ := setPD(fwdCacheState, fwdPassDirty))
@@ -474,8 +501,11 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   /* ======== Write Directory ======== */
   val metaW_valid_s3_a = sinkA_req_s3 && !need_mshr_s3_a && !req_get_s3 && !req_prefetch_s3 && !cmo_cbo_s3 // get & prefetch that hit will not write meta
+  // Also write directory on:
+  //  1. SnpOnce/SnpOnceFwd nesting WriteCleanFull under UD/UC/SC
   val metaW_valid_s3_b = sinkB_req_s3 && !need_mshr_s3_b && dirResult_s3.hit &&
-    !isSnpOnceX(req_s3.chiOpcode.get) && !isSnpStashX(req_s3.chiOpcode.get) && !isSnpQuery(req_s3.chiOpcode.get) && (
+    (!isSnpOnceX(req_s3.chiOpcode.get) || req_s3.snpHitReleaseToClean) && 
+    !isSnpStashX(req_s3.chiOpcode.get) && !isSnpQuery(req_s3.chiOpcode.get) && (
       meta_s3.state === TIP || meta_s3.state === BRANCH && isSnpToN(req_s3.chiOpcode.get)
     )
   val metaW_valid_s3_c = sinkC_req_s3 && dirResult_s3.hit
@@ -622,11 +652,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     * 
     * *NOTICE: Never allow 'b_inv_dirty' on SnpStash*, SnpQuery and other future snoops that would
     *          leave cache line state untouched.
-    * 
-    * *TODO: A SnpOnce* nesting WriteCleanFull would result in SnpResp*_I_PD, which was simple to
-    *        implement but could be further optimized.
+    *          Never allow 'b_inv_dirty' on SnpOnce* nesting WriteCleanFull, which would end with SC.
     */
-  io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitRelease &&
+  io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitReleaseToInval &&
     !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))
   io.nestedwb.b_toB.foreach(_ :=
     task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && source_req_s3.meta.state === BRANCH

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -426,6 +426,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       false.B
     ) // TODO: parameterize this
     sink_resp_s3.bits.size := log2Ceil(blockBytes).U
+    sink_resp_s3.bits.meta := metaW_s3_b
+    sink_resp_s3.bits.metaWen := metaW_valid_s3_b
 
   }.otherwise { // req_s3.fromC
     sink_resp_s3.bits.opcode := ReleaseAck

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -369,7 +369,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     }
   }
 
-  val sink_resp_s3_b_meta = Wire(MetaEntry())
+  val sink_resp_s3_b_meta = MetaEntry()
   val sink_resp_s3_b_metaWen = Wire(Bool())
 
   sink_resp_s3.valid := task_s3.valid && !mshr_req_s3 && !need_mshr_s3

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -396,7 +396,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       Cat(true.B, true.B)   -> SnpRespDataFwded
     )))
     sink_resp_s3.bits.resp.foreach(_ := Mux(
-      req_s3.snpHitReleaseToInval && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
+      req_s3.snpHitRelease && !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)),
       setPD(
         // On directory hit under non-invalidating snoop nesting WriteCleanFull, 
         // excluding SnpStashX and SnpQuery:

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -88,8 +88,11 @@ class RXSNP(
       (!s.bits.dirHit || !s.bits.s_cmoresp) && s.bits.metaState =/= INVALID &&
       RegNext(s.bits.w_replResp) && s.bits.w_rprobeacklast && !s.bits.w_releaseack
     )).asUInt
-  val releaseToBNestSnpMask = replaceNestSnpMask & VecInit(io.msInfo.map(s =>
-      s.bits.releaseToB
+  val releaseToInvalNestSnpMask = replaceNestSnpMask & VecInit(io.msInfo.map(s =>
+      !s.bits.releaseToClean
+    )).asUInt
+  val releaseToCleanNestSnpMask = replaceNestSnpMask & VecInit(io.msInfo.map(s =>
+      s.bits.releaseToClean
     )).asUInt
   val replaceDataMask = VecInit(io.msInfo.map(_.bits.replaceData)).asUInt
 
@@ -159,7 +162,8 @@ class RXSNP(
     task.mergeA := false.B
     task.aMergeTask := 0.U.asTypeOf(new MergeTaskBundle)
     task.snpHitRelease := replaceNestSnpMask.orR
-    task.snpHitReleaseToB := releaseToBNestSnpMask.orR
+    task.snpHitReleaseToInval := releaseToInvalNestSnpMask.orR
+    task.snpHitReleaseToClean := releaseToCleanNestSnpMask.orR
     task.snpHitReleaseWithData := (replaceNestSnpMask & replaceDataMask).orR
     task.snpHitReleaseState := replaceNestSnpState
     task.snpHitReleaseDirty := replaceNestSnpDirty

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -571,7 +571,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast
   io.msInfo.bits.replaceData := mp_release.opcode === ReleaseData
-  io.msInfo.bits.releaseToB := false.B
+  io.msInfo.bits.releaseToClean := false.B
   io.msInfo.bits.metaState := meta.state
   io.msInfo.bits.metaDirty := meta.dirty
   io.msInfo.bits.probeDirty := probeDirty

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -240,7 +240,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.aMergeTask       := req_s3.aMergeTask
   ms_task.txChannel        := 0.U
   ms_task.snpHitRelease    := false.B
-  ms_task.snpHitReleaseToB := false.B
+  ms_task.snpHitReleaseToInval := false.B
+  ms_task.snpHitReleaseToClean := false.B
   ms_task.snpHitReleaseWithData := false.B
   ms_task.snpHitReleaseIdx := 0.U
   ms_task.snpHitReleaseState := 0.U

--- a/src/main/scala/coupledL2/tl2tl/SinkB.scala
+++ b/src/main/scala/coupledL2/tl2tl/SinkB.scala
@@ -50,7 +50,8 @@ class SinkB(implicit p: Parameters) extends L2Module {
     task.wayMask := Fill(cacheParams.ways, "b1".U)
     task.reqSource := MemReqSource.NoWhere.id.U // Ignore
     task.snpHitRelease := false.B
-    task.snpHitReleaseToB := false.B
+    task.snpHitReleaseToInval := false.B
+    task.snpHitReleaseToClean := false.B
     task.snpHitReleaseWithData := false.B
     task.snpHitReleaseIdx := 0.U
     task.snpHitReleaseState := 0.U


### PR DESCRIPTION
**SnpOnceX**: SnpOnce, SnpOnceFwd
**SnpToB**: SnpClean, SnpShared, SnpNotSharedDirty, SnpCleanFwd,
            SnpSharedFwd, SnpNotSharedDirtyFwd

* 1) Common: Distinguish WriteBackFull/WriteEvictFull/WriteEvictOrEvict/ Evict nesting from WriteCleanFull using ```snpHitReleaseToInval``` and ```snpHitReleaseToClean``` for better robustness and readability

* 2) MainPipe: For **SnpOnceX** and **SnpToB** nesting WriteCleanFull, redirect cache state to SC

* 3) MainPipe: Update directory meta on **SnpOnceX** nesting WriteCleanFull

* 4) MainPipe: For **SnpCleanShared** nesting WriteCleanFull, allow transition to UC

* 5) MSHR: Clear dirty flag in directory meta on ```mp_probeack``` of **SnpOnceX** nesting WriteCleanFull

* 6) MSHR: For **SnpOnceX** nesting WriteCleanFull, allow PassDirty