### PR TITLE
fix(MSHR): CBWrData with UC/SC on WriteEvictOrEvict

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -586,7 +586,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cbwrdata.homeNID.get := 0.U
     mp_cbwrdata.dbID.get := 0.U
     mp_cbwrdata.chiOpcode.get := CopyBackWrData
-    mp_cbwrdata.resp.get := Mux(isValid(meta.state), UD_PD, I)
+    mp_cbwrdata.resp.get := setPD(metaChi, meta.dirty)
     mp_cbwrdata.fwdState.get := 0.U
     mp_cbwrdata.pCrdType.get := 0.U // TODO
     mp_cbwrdata.retToSrc.get := req.retToSrc.get // DontCare

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1337,12 +1337,14 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     when (io.nestedwb.b_toB.get && req.fromA) {
       meta.state := Mux(meta.state >= BRANCH, BRANCH, INVALID)
       meta.dirty := false.B
+      probeDirty := false.B
     }
     when (io.nestedwb.b_toN.get && req.fromA) {
       meta.state := INVALID
       dirResult.hit := false.B
       meta.dirty := false.B
       meta.clients := Fill(clientBits, false.B)
+      probeDirty := false.B
       state.w_replResp := cmo_cbo // never query replacer on CMO
       req.aliasTask.foreach(_ := false.B)
     }

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -586,7 +586,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cbwrdata.homeNID.get := 0.U
     mp_cbwrdata.dbID.get := 0.U
     mp_cbwrdata.chiOpcode.get := CopyBackWrData
-    mp_cbwrdata.resp.get := setPD(metaChi, meta.dirty)
+    mp_cbwrdata.resp.get := setPD(metaChi, meta.dirty || probeDirty)
     mp_cbwrdata.fwdState.get := 0.U
     mp_cbwrdata.pCrdType.get := 0.U // TODO
     mp_cbwrdata.retToSrc.get := req.retToSrc.get // DontCare


### PR DESCRIPTION
* Use ```metaChi``` directly for future robustness