### PR TITLE
fix(MSHR): SnpQuery response SnpResp_I on nested Evict

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1030,6 +1030,10 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
           req_writeEvictOrEvict := true.B
         }
       }
+      when (isEvict) {
+        meta.state := INVALID
+        meta.dirty := false.B
+      }
     }.elsewhen (mp_cbwrdata_valid) {
       state.s_cbwrdata.get := true.B
       meta.state := INVALID

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -334,17 +334,12 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /**
       * NOTICE: On Stash and Query:
       * the cache state must maintain unchanged on nested WriteBack
-      * the cache state should be INVALID on nested Evict
      */
     when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
-        req_s3.snpHitReleaseState === INVALID,
-        I,
-        Mux(
-          req_s3.snpHitReleaseState === BRANCH,
-          SC,
-          Mux(req_s3.snpHitReleaseDirty, UD, UC)
-        )
+        req_s3.snpHitReleaseState === BRANCH,
+        SC,
+        Mux(req_s3.snpHitReleaseDirty, UD, UC)
       )
     }
   }

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -331,12 +331,20 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   }
 
   when (req_s3.snpHitRelease) {
-    // *NOTICE: On Stash and Query, the cache state must maintain unchanged on nested WriteBack
+    /**
+      * NOTICE: On Stash and Query:
+      * the cache state must maintain unchanged on nested WriteBack
+      * the cache state should be INVALID on nested Evict
+     */
     when (isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get)) {
       respCacheState := Mux(
-        req_s3.snpHitReleaseState === BRANCH,
-        SC,
-        Mux(req_s3.snpHitReleaseDirty, UD, UC)
+        req_s3.snpHitReleaseState === INVALID,
+        I,
+        Mux(
+          req_s3.snpHitReleaseState === BRANCH,
+          SC,
+          Mux(req_s3.snpHitReleaseDirty, UD, UC)
+        )
       )
     }
   }


### PR DESCRIPTION
* Bug description:
SnpQuery response SnpResp_UC instead of SnpResp_I,
when nesting Evict

* Bug fixation:
In MSHR, Evict task sets meta state to INVALID immediately;

* SnpStashX has same problem(fixed together)