### PR TITLE
fix (MSHR): resolve read/writeEvictOrEvit conflict on txrsp

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -287,6 +287,7 @@ class FSMState(implicit p: Parameters) extends L2Bundle {
 
   // CHI
   val s_compack = chiOpt.map(_ => Bool())
+  val s_compack_writeEvictOrEvict = chiOpt.map(_ => Bool())
   val s_cbwrdata = chiOpt.map(_ => Bool())
   val s_reissue = chiOpt.map(_ => Bool())
   val s_dct = chiOpt.map(_ => Bool())


### PR DESCRIPTION
- Conflit when ReadNotShareDirty and WriteEvictOrEvit use txrsp to send compAck simultaneously
- Seperate MSHR inner state s_compack for Read* and s_compack_writeEvictOrEvict for evict to arbiter
- ReadNotShareDirty request has high priority and will stall writeEvictOrEvict
- Seperate sources of TgtID and Txnid in compAck