### PR TITLE
fix(SinkC): dinstinguish release corrupt/denied error

### DIFF
--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -79,8 +79,8 @@ class SinkC(implicit p: Parameters) extends L2Module {
     task.param := c.param
     task.size := c.size
     task.sourceId := c.source
-    task.corrupt := c.corrupt && (c.opcode == ProbeAckData).asBool
-    task.denied := c.corrupt && (c.opcode == ProbeAck).asBool
+    task.corrupt := c.corrupt && ((c.opcode == ProbeAckData).asBool || (c.opcode == ReleaseData).asBool)
+    task.denied := c.corrupt && ((c.opcode == ProbeAck).asBool || (c.opcode == Release).asBool)
     task.bufIdx := 0.U(bufIdxBits.W)
     task.needProbeAckData := false.B
     task.mshrTask := false.B


### PR DESCRIPTION
* Dinstinguish corrupt/denied error by opcode in channel C
   * Channel C does not have `denied`
* DataErr(corrupt): opcode = ProbeAckData/ReleaseData
* TagErr(denied): opcode = ProbeAck/Release