### PR TITLE
fix(MainPipe, MSHR): report DataCheck error to BEU

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -143,6 +143,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val allowRetry = chiOpt.map(_ => Bool())
   val memAttr = chiOpt.map(_ => new MemAttr)
   val traceTag = chiOpt.map(_ => Bool())
+  val dataCheckErr = chiOpt.map(_ => Bool())
 
   def toCHIREQBundle(): CHIREQ = {
     val req = WireInit(0.U.asTypeOf(new CHIREQ()))
@@ -249,6 +250,7 @@ class RespInfoBundle(implicit p: Parameters) extends L2Bundle
   val pCrdType = chiOpt.map(_ => UInt(PCRDTYPE_WIDTH.W))
   val respErr = chiOpt.map(_ => UInt(RESPERR_WIDTH.W))
   val traceTag = chiOpt.map(_ => Bool())
+  val dataCheckErr = chiOpt.map(_ => Bool())
 }
 
 class RespBundle(implicit p: Parameters) extends L2Bundle {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -108,6 +108,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val gotPCrdGrant = RegInit(false.B)
   val denied = RegInit(false.B)
   val corrupt = RegInit(false.B)
+  val dataCheckErr = RegInit(false.B)
   val cbWrDataTraceTag = RegInit(false.B)
   val metaChi = ParallelLookUp(
     Cat(meta.dirty, meta.state),
@@ -145,6 +146,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     pcrdtype := 0.U
     denied := false.B
     corrupt := false.B
+    dataCheckErr := false.B
     cbWrDataTraceTag := false.B
 
     retryTimes := 0.U
@@ -807,6 +809,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       accessed = true.B
     )
 
+    // CHI
+    mp_grant.dataCheckErr.get := dataCheckErr
+
     mp_grant
   }
 
@@ -1112,6 +1117,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         gotGrantData := true.B
         denied := denied || nderr
         corrupt := corrupt || derr || nderr || rxdatCorrupt
+        dataCheckErr := dataCheckErr || rxdat.bits.dataCheckErr.getOrElse(false.B)
       }
     }
 
@@ -1127,6 +1133,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       homenid := rxdat.bits.homeNID.getOrElse(0.U)
       denied := denied || nderr
       corrupt := corrupt || derr || nderr || rxdatCorrupt
+      dataCheckErr := dataCheckErr || rxdat.bits.dataCheckErr.getOrElse(false.B)
       req.traceTag.get := req.traceTag.get || rxdat.bits.traceTag.getOrElse(false.B)
     }
   }

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -148,7 +148,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   val tagError_s3     = io.dirResp_s3.error || meta_s3.tagErr
   val dataError_s3    = meta_s3.dataErr
-  val l2Error_s3      = io.dirResp_s3.error
+  val l2Error_s3      = io.dirResp_s3.error || req_s3.mshrTask && req_s3.dataCheckErr.getOrElse(false.B)
 
   val mshr_req_s3     = req_s3.mshrTask
   val sink_req_s3     = !mshr_req_s3

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -146,10 +146,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val meta_s3         = dirResult_s3.meta
   val req_s3          = task_s3.bits
 
-  val tagError_s3     = io.dirResp_s3.error || meta_s3.tagErr
-  val dataError_s3    = meta_s3.dataErr
-  val l2Error_s3      = io.dirResp_s3.error || req_s3.mshrTask && req_s3.dataCheckErr.getOrElse(false.B)
-
   val mshr_req_s3     = req_s3.mshrTask
   val sink_req_s3     = !mshr_req_s3
   val sinkA_req_s3    = !mshr_req_s3 && req_s3.fromA
@@ -197,6 +193,10 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   val cache_alias               = req_acquire_s3 && dirResult_s3.hit && meta_s3.clients(0) &&
                               meta_s3.alias.getOrElse(0.U) =/= req_s3.alias.getOrElse(0.U)
+
+  val tagError_s3               = io.dirResp_s3.error || meta_s3.tagErr
+  val dataError_s3              = meta_s3.dataErr
+  val l2Error_s3                = io.dirResp_s3.error || mshr_req_s3 && req_s3.dataCheckErr.getOrElse(false.B)
 
   val mshr_refill_s3 = mshr_accessackdata_s3 || mshr_hintack_s3 || mshr_grant_s3 // needs refill to L2 DS
   val replResp_valid_s3 = io.replResp.valid

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -66,21 +66,22 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   io.in.set := 0.U(setBits.W)
   io.in.tag := 0.U(tagBits.W)
 
-  io.in.respInfo.opcode        := DontCare
-  io.in.respInfo.param         := DontCare
-  io.in.respInfo.last          := last
-  io.in.respInfo.dirty         := DontCare
-  io.in.respInfo.isHit         := DontCare
-  io.in.respInfo.chiOpcode.get := io.out.bits.opcode
-  io.in.respInfo.txnID.get     := io.out.bits.txnID
-  io.in.respInfo.srcID.get     := io.out.bits.srcID
-  io.in.respInfo.homeNID.get   := io.out.bits.homeNID
-  io.in.respInfo.dbID.get      := io.out.bits.dbID
-  io.in.respInfo.resp.get      := io.out.bits.resp
-  io.in.respInfo.pCrdType.get  := DontCare // RXDAT Channel does not have a pCrdType field
-  io.in.respInfo.respErr.get   := io.out.bits.respErr
-  io.in.respInfo.traceTag.get  := io.out.bits.traceTag
-  io.in.respInfo.corrupt       := io.out.bits.respErr === RespErrEncodings.DERR || io.out.bits.respErr === RespErrEncodings.NDERR || dataCheck || poison
+  io.in.respInfo.opcode           := DontCare
+  io.in.respInfo.param            := DontCare
+  io.in.respInfo.last             := last
+  io.in.respInfo.dirty            := DontCare
+  io.in.respInfo.isHit            := DontCare
+  io.in.respInfo.chiOpcode.get    := io.out.bits.opcode
+  io.in.respInfo.txnID.get        := io.out.bits.txnID
+  io.in.respInfo.srcID.get        := io.out.bits.srcID
+  io.in.respInfo.homeNID.get      := io.out.bits.homeNID
+  io.in.respInfo.dbID.get         := io.out.bits.dbID
+  io.in.respInfo.resp.get         := io.out.bits.resp
+  io.in.respInfo.pCrdType.get     := DontCare // RXDAT Channel does not have a pCrdType field
+  io.in.respInfo.respErr.get      := io.out.bits.respErr
+  io.in.respInfo.traceTag.get     := io.out.bits.traceTag
+  io.in.respInfo.corrupt          := io.out.bits.respErr === RespErrEncodings.DERR || io.out.bits.respErr === RespErrEncodings.NDERR || dataCheck || poison
+  io.in.respInfo.dataCheckErr.get := dataCheck
 
   io.out.ready := true.B
 


### PR DESCRIPTION
* Problem Description:
    * DataCheck error detected in L2 cache will not be reported anywhere previously.

* Fixation:
    * In MSHR, record  DataCheck error (mp_grant).
    * In MainPipe, report detected DataCheck with original ECC error report datapath
  
* UnCache DataCheck error (in MMIOBridge) will be processed in L1 UC