### PR TITLE
fix(MSHR): fix bugs of DBID in CompAck of WriteEvictOrEvict

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -286,7 +286,8 @@ class FSMState(implicit p: Parameters) extends L2Bundle {
   val w_replResp = Bool()
 
   // CHI
-  val s_compack = chiOpt.map(_ => Bool())
+  val s_rcompack = chiOpt.map(_ => Bool())
+  val s_wcompack = chiOpt.map(_ => Bool())
   val s_cbwrdata = chiOpt.map(_ => Bool())
   val s_reissue = chiOpt.map(_ => Bool())
   val s_dct = chiOpt.map(_ => Bool())

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1240,6 +1240,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
   val no_schedule = state.s_refill && state.s_probeack && state.s_release &&
     state.s_rcompack.getOrElse(true.B) &&
+    state.s_wcompack.getOrElse(true.B) &&
     state.s_cbwrdata.getOrElse(true.B) &&
     state.s_reissue.getOrElse(true.B) &&
     state.s_dct.getOrElse(true.B) &&

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -878,7 +878,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     // need Acquire downwards
     when (need_acquire_s3_a) {
       alloc_state.s_acquire := false.B
-      alloc_state.s_compack.get := !need_compack_s3_a
+      alloc_state.s_rcompack.get := !need_compack_s3_a
       alloc_state.w_grantfirst := false.B
       alloc_state.w_grantlast := false.B
       alloc_state.w_grant := false.B


### PR DESCRIPTION
- Seperate `s_compack` of read/dataless and write transactions into two status registers `s_rcompack` and `s_wcompack`
- If the downstream returns a combined data and response (CompData), RN should return CompAck whose TgtID is set to the HomeNID of CompData, and TxnID is set to the DBID of CompData. If the downstream returns a seperate data and response, or return only a response (Comp), RN should return CompAck (if necessary) whose TgtID is set to the SrcID of RespSepData or Comp, and TxnID is set to the DBID of that. In this commit, `srcid`, `homenid` and `dbid` are replaced for better code readability.