### PR TITLE
fix(RXSNP): block RXSNP on CMO ```rprobe``` and ```cmometaw``` task

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -222,6 +222,7 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle with HasTLChannelBits {
   val s_release = Bool()
   val s_refill = Bool()
   val s_cmoresp = Bool()
+  val s_cmometaw = Bool()
   val w_releaseack = Bool()
   val w_replResp = Bool()
   val w_rprobeacklast = Bool()

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -930,7 +930,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cmometaw.meta := meta
     mp_cmometaw.meta.clients := meta.clients & Fill(clientBits, !probeGotN)
     mp_cmometaw.meta.dirty := false.B
-    mp_cmometaw.meta.state := TIP
+    mp_cmometaw.meta.state := TIP // write TIP for compensation of ProbeAck TtoB/TtoN by cbo.clean
     mp_cmometaw.metaWen := true.B
 
     mp_cmometaw.tagWen := false.B

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -925,11 +925,12 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cmometaw.needHint.foreach(_ := false.B)
     mp_cmometaw.dirty := hitDirty
     
-    // write meta for compensation of ProbeAck TtoB by cbo.clean
+    // write meta for compensation of ProbeAck TtoB/TtoN by cbo.clean
+    // *NOTICE: There is no possible nest for 'cmometaw' task, snoops should be blocked by RXSNP.
     mp_cmometaw.meta := meta
     mp_cmometaw.meta.clients := meta.clients & Fill(clientBits, !probeGotN)
     mp_cmometaw.meta.dirty := false.B
-    mp_cmometaw.meta.state := Mux(isT(meta.state), TIP, meta.state) 
+    mp_cmometaw.meta.state := TIP
     mp_cmometaw.metaWen := true.B
 
     mp_cmometaw.tagWen := false.B
@@ -1329,6 +1330,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.s_release := state.s_release
   io.msInfo.bits.s_refill := state.s_refill
   io.msInfo.bits.s_cmoresp := state.s_cmoresp
+  io.msInfo.bits.s_cmometaw := state.s_cmometaw
   io.msInfo.bits.w_releaseack := state.w_releaseack
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -924,10 +924,14 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cmometaw.fromL2pft.foreach(_ := false.B)
     mp_cmometaw.needHint.foreach(_ := false.B)
     mp_cmometaw.dirty := hitDirty
+    
+    // write meta for compensation of ProbeAck TtoB by cbo.clean
     mp_cmometaw.meta := meta
+    mp_cmometaw.meta.clients := meta.clients & Fill(clientBits, !probeGotN)
     mp_cmometaw.meta.dirty := false.B
-    mp_cmometaw.meta.state := TIP // write TIP for compensation of ProbeAck TtoB by cbo.clean
+    mp_cmometaw.meta.state := Mux(isT(meta.state), TIP, meta.state) 
     mp_cmometaw.metaWen := true.B
+
     mp_cmometaw.tagWen := false.B
     mp_cmometaw.dsWen := false.B
     mp_cmometaw.wayMask := 0.U(cacheParams.ways.W)

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -52,11 +52,17 @@ class RXSNP(
     *    the snooped block is still in RefillBuffer rather than DS.
     * 4. After MSHR sends out WriteBackFull/Evict and write refilled data into DS, snoop should be **nested**, still
     *    because snoop has higher priority than request.
+    * 5. Before MSHR completes Probe to L1 for alias replacing, snoop should be **blocked*.
+    * 6. Before MSHR sends out WriteCleanFull/WriteBackFull/Evict or sends 'cmometaw' task onto MainPipe, snoop should 
+    *    be **blocked**, because the snooped block might be performing silent transition of TRUNK to TIP (UC -> UC),
+    *    while waitings for DS write were unnecessary since the silent transition would only happen on clean block.
     */
   val reqBlockSnpMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === task.set && s.bits.reqTag === task.tag &&
-    (s.bits.w_grantfirst || s.bits.aliasTask.getOrElse(false.B) && !s.bits.w_rprobeacklast) &&
-    (s.bits.blockRefill || s.bits.w_releaseack) && !s.bits.willFree
+    s.valid && s.bits.set === task.set && s.bits.reqTag === task.tag && (
+      s.bits.w_grantfirst || // See [2], [3] above with 's.bits.blockRefill'
+      s.bits.aliasTask.getOrElse(false.B) && !s.bits.w_rprobeacklast || // See [5] above
+      !s.bits.s_cmoresp && (!s.bits.w_rprobeacklast || !s.bits.s_cmometaw) // See [6] above
+    ) && (s.bits.blockRefill || s.bits.w_releaseack) && !s.bits.willFree
   )).asUInt
   val reqBlockSnp = reqBlockSnpMask.orR
 

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -566,8 +566,8 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.w_grantfirst := state.w_grantfirst
   io.msInfo.bits.s_refill := state.s_refill
   io.msInfo.bits.s_release := state.s_release
-  io.msInfo.bits.s_cmoresp := false.B
-  io.msInfo.bits.s_cmometaw := false.B
+  io.msInfo.bits.s_cmoresp := true.B
+  io.msInfo.bits.s_cmometaw := true.B
   io.msInfo.bits.w_releaseack := state.w_releaseack
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -567,6 +567,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.s_refill := state.s_refill
   io.msInfo.bits.s_release := state.s_release
   io.msInfo.bits.s_cmoresp := false.B
+  io.msInfo.bits.s_cmometaw := false.B
   io.msInfo.bits.w_releaseack := state.w_releaseack
   io.msInfo.bits.w_replResp := state.w_replResp
   io.msInfo.bits.w_rprobeacklast := state.w_rprobeacklast


### PR DESCRIPTION
* Before MSHR sends out WriteCleanFull/WriteBackFull/Evict or sends
  ```cmometaw``` task onto MainPipe, snoop should be **blocked**,
  because the snooped block might be performing silent transition of
  TRUNK to TIP (UC -> UC).
  While, waitings for DS write were unncessary since the silent
  transition would only happen on clean block.