### PR TITLE
fix(MSHR): SnpOnceFwd should reply UC -> UC on UC state

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -314,7 +314,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     isSnpOnceX(req_chiOpcode) ->
       Mux(req.snpHitReleaseToInval, I, Mux(
         req.snpHitReleaseToClean,
-        Mux(req.snpHitReleaseMeta.dirty, SC, UC),
+        Mux(req.snpHitReleaseMeta.dirty, SC, metaChi),
         Mux(probeDirty || meta.dirty, UD, metaChi)
       )),
     (isSnpStashX(req_chiOpcode) || isSnpQuery(req_chiOpcode)) ->


### PR DESCRIPTION
* On multiple nesting under WriteCleanFull, the cache state may sit at interval state of UC.

* SnpOnceFwd always goes into MSHR as DCT, while SnpOnce nesting WriteCleanFull with TIP would never go into MSHR.