### PR TITLE
fix(MainPipe, MSHR): update MSHR meta on ProbeAck/ProbeAckData

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -331,6 +331,8 @@ class NestedWriteback(implicit p: Parameters) extends L2Bundle {
   val c_set_tip = Bool()
   // Nested Snoop invalidates block
   val b_inv_dirty = Bool()
+  // Nested Snoop cleans block
+  val b_cln_dirty = Bool()
 
   val b_toB = chiOpt.map(_ => Bool())
   val b_toN = chiOpt.map(_ => Bool())

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -331,11 +331,10 @@ class NestedWriteback(implicit p: Parameters) extends L2Bundle {
   val c_set_tip = Bool()
   // Nested Snoop invalidates block
   val b_inv_dirty = Bool()
-  // Nested Snoop cleans block
-  val b_cln_dirty = Bool()
 
   val b_toB = chiOpt.map(_ => Bool())
   val b_toN = chiOpt.map(_ => Bool())
+  val b_toClean = chiOpt.map(_ => Bool())
 }
 
 class PrefetchCtrlFromCore extends Bundle {

--- a/src/main/scala/coupledL2/Consts.scala
+++ b/src/main/scala/coupledL2/Consts.scala
@@ -55,6 +55,9 @@ object MetaData {
   def isToB(param: UInt): Bool = {
     param === TLPermissions.TtoB || param === TLPermissions.BtoB
   }
+  def isToT(param: UInt): Bool = {
+    param === TLPermissions.TtoT
+  }
   def isT(state: UInt): Bool = state(1)
   def isParamFromT(param: UInt): Bool = {
     param === TLPermissions.TtoN || param === TLPermissions.TtoB || param === TLPermissions.TtoT

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -650,7 +650,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
         isSnpCleanShared(req_chiOpcode) ||
         isSnpOnceX(req_chiOpcode) && req.snpHitReleaseToClean
       ) || isSnpOnceX(req_chiOpcode) && probeDirty,
-      // Directory would always be missing on nesting WriteBackFull/WriteEvict*/Evict
       state = Mux(
         snpToN,
         INVALID,

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1366,14 +1366,14 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
     }
-  }
-  when (nestedwb_hit_match) {
     when (io.nestedwb.b_inv_dirty && req.fromA) {
       meta.dirty := false.B
       meta.state := INVALID
       probeDirty := false.B
     }
-    when (io.nestedwb.b_cln_dirty && req.fromA) {
+  }
+  when (nestedwb_hit_match) {
+    when (io.nestedwb.b_toClean.get && req.fromA) {
       meta.dirty := false.B
       probeDirty := false.B
     }

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -69,6 +69,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val gotDirty = RegInit(false.B)
   val gotGrantData = RegInit(false.B)
   val probeDirty = RegInit(false.B)
+  val releaseDirty = RegInit(false.B)
   val timer = RegInit(0.U(64.W)) // for performance analysis
   val beatCnt = RegInit(0.U(log2Ceil(beatSize).W))
 
@@ -136,6 +137,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     gotDirty    := false.B
     gotGrantData := false.B
     probeDirty  := false.B
+    releaseDirty := false.B
     timer       := 1.U
     beatCnt     := 0.U
 
@@ -665,7 +667,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     )
     mp_probeack.metaWen := !req.snpHitReleaseToInval
     mp_probeack.tagWen := false.B
-    mp_probeack.dsWen := !snpToN && probeDirty && meta.clients.orR
+    mp_probeack.dsWen := !snpToN && probeDirty && !releaseDirty
     mp_probeack.wayMask := 0.U(cacheParams.ways.W)
     mp_probeack.reqSource := 0.U(MemReqSource.reqSourceBits.W)
     mp_probeack.replTask := false.B
@@ -1361,6 +1363,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.dirty := true.B
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
+      releaseDirty := true.B
     }
     when (io.nestedwb.c_set_tip) {
       meta.state := TIP

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1106,6 +1106,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     when (isToB(c_resp.bits.param)) {
       meta.state := Mux(isT(meta.state), TIP, meta.state)
     }
+    when (isToT(c_resp.bits.param)) {
+      assert(false.B, "ProbeAck/ProbeAckData TtoT not fully supported")
+    }
 
     // CMO update release on ProbeAck/ProbeAckData
     when (req_cboClean) {
@@ -1366,24 +1369,24 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
     }
+  }
+  when (nestedwb_hit_match) {
     when (io.nestedwb.b_inv_dirty && req.fromA) {
       meta.dirty := false.B
       meta.state := INVALID
       probeDirty := false.B
     }
-  }
-  when (nestedwb_hit_match) {
-    when (io.nestedwb.b_toB.get && req.fromA) {
-      meta.state := Mux(meta.state >= BRANCH, BRANCH, INVALID)
+    when (io.nestedwb.b_cln_dirty && req.fromA) {
       meta.dirty := false.B
       probeDirty := false.B
+    }
+    when (io.nestedwb.b_toB.get && req.fromA) {
+      meta.state := Mux(meta.state >= BRANCH, BRANCH, INVALID)
     }
     when (io.nestedwb.b_toN.get && req.fromA) {
       meta.state := INVALID
       dirResult.hit := false.B
-      meta.dirty := false.B
       meta.clients := Fill(clientBits, false.B)
-      probeDirty := false.B
       state.w_replResp := cmo_cbo // never query replacer on CMO
       req.aliasTask.foreach(_ := false.B)
     }

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1106,9 +1106,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     when (isToB(c_resp.bits.param)) {
       meta.state := Mux(isT(meta.state), TIP, meta.state)
     }
-    when (isToT(c_resp.bits.param)) {
-      assert(false.B, "ProbeAck/ProbeAckData TtoT not fully supported")
-    }
 
     // CMO update release on ProbeAck/ProbeAckData
     when (req_cboClean) {

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -668,6 +668,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     */
   io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitReleaseToInval &&
     !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))
+  io.nestedwb.b_cln_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && !source_req_s3.meta.dirty
   io.nestedwb.b_toB.foreach(_ :=
     task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && source_req_s3.meta.state === BRANCH
   )

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -668,12 +668,14 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     */
   io.nestedwb.b_inv_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.snpHitReleaseToInval &&
     !(isSnpStashX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get))
-  io.nestedwb.b_cln_dirty := task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && !source_req_s3.meta.dirty
   io.nestedwb.b_toB.foreach(_ :=
     task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && source_req_s3.meta.state === BRANCH
   )
   io.nestedwb.b_toN.foreach(_ :=
     task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && source_req_s3.meta.state === INVALID
+  )
+  io.nestedwb.b_toClean.foreach(_ :=
+    task_s3.valid && task_s3.bits.fromB && source_req_s3.metaWen && !source_req_s3.meta.dirty
   )
 
   io.nestedwbData := c_releaseData_s3.asTypeOf(new DSBlock)

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -440,7 +440,6 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData
   io.nestedwb.c_set_tip := false.B
   io.nestedwb.b_inv_dirty := false.B
-  io.nestedwb.b_cln_dirty := false.B
 
   io.nestedwbData := c_releaseData_s3.asTypeOf(new DSBlock)
 

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -440,6 +440,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData
   io.nestedwb.c_set_tip := false.B
   io.nestedwb.b_inv_dirty := false.B
+  io.nestedwb.b_cln_dirty := false.B
 
   io.nestedwbData := c_releaseData_s3.asTypeOf(new DSBlock)
 


### PR DESCRIPTION
* For unified meta reading now on MainPipe, ```dirty``` bits in MSHR were also necessary to be updated on ```mp_probeack``` with clean meta write.
* For better robustness and readability, a new register ```releaseDirty``` is introduced to prevent DataStorage write of ```mp_probeack``` with nested ReleaseData. And, with this change, ProbeAck/ProbeAckData toN from L1 would be allowed on L2 upstream Probe toB.