### PR TITLE
fix(MSHR): never overwrite directory tags on CBOAck

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -788,7 +788,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       accessed = req_acquire || req_get
     )
     mp_grant.metaWen := !cmo_cbo
-    mp_grant.tagWen := !dirResult.hit
+    mp_grant.tagWen := !cmo_cbo && !dirResult.hit
     mp_grant.dsWen := gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)


### PR DESCRIPTION
* Might cause functional problems, while not observed yet. 
* Might cause cache line loss, resulting in unexpected silent eviction.

**The Directory tag writes are protected by MainPipe now, so we will have no functional problems:**
```scala
  io.tagWReq.valid := task_s3.valid && req_s3.tagWen && mshr_refill_s3 && !retry
```