### PR TITLE
fix(RXSNP): fix x_value in vcs

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -58,7 +58,7 @@ class RXSNP(
     *    while waitings for DS write were unnecessary since the silent transition would only happen on clean block.
     */
   val reqBlockSnpMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === task.set && s.bits.reqTag === task.tag && (
+    rxsnp.valid && s.valid && s.bits.set === task.set && s.bits.reqTag === task.tag && (
       s.bits.w_grantfirst || // See [2], [3] above with 's.bits.blockRefill'
       s.bits.aliasTask.getOrElse(false.B) && !s.bits.w_rprobeacklast || // See [5] above
       !s.bits.s_cmoresp && (!s.bits.w_rprobeacklast || !s.bits.s_cmometaw) // See [6] above
@@ -78,13 +78,13 @@ class RXSNP(
     *    be **blocked**.
     */
   val cmoBlockSnpMask = VecInit(io.msInfo.map(s => 
-    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.dirHit && isValid(s.bits.meta.state) &&
+    rxsnp.valid && s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && s.bits.dirHit && isValid(s.bits.meta.state) &&
     !s.bits.s_cmoresp && (!s.bits.s_release || !s.bits.w_rprobeacklast) &&
     !s.bits.willFree
   )).asUInt
   val cmoBlockSnp = cmoBlockSnpMask.orR
   val replaceBlockSnpMask = VecInit(io.msInfo.map(s =>
-    s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit && isValid(s.bits.meta.state) &&
+    rxsnp.valid && s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && !s.bits.dirHit && isValid(s.bits.meta.state) &&
     s.bits.s_cmoresp && s.bits.w_replResp && (!s.bits.w_rprobeacklast || s.bits.w_releaseack || !RegNext(s.bits.w_replResp)) &&
     !s.bits.willFree
   )).asUInt
@@ -93,7 +93,7 @@ class RXSNP(
   // '!s.bits.dirHit'     : Nesting a Cache Replacement subsequent release
   // '!s.bits.s_cmoresp'  : Nesting a CMO subsequent release
   val replaceNestSnpMask = VecInit(io.msInfo.map(s =>
-      s.valid && io.rxsnp.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && 
+      rxsnp.valid && s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag &&
       (!s.bits.dirHit || !s.bits.s_cmoresp) && s.bits.meta.state =/= INVALID &&
       RegNext(s.bits.w_replResp) && s.bits.w_rprobeacklast && !s.bits.w_releaseack
     )).asUInt

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -93,7 +93,7 @@ class RXSNP(
   // '!s.bits.dirHit'     : Nesting a Cache Replacement subsequent release
   // '!s.bits.s_cmoresp'  : Nesting a CMO subsequent release
   val replaceNestSnpMask = VecInit(io.msInfo.map(s =>
-      s.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && 
+      s.valid && io.rxsnp.valid && s.bits.set === task.set && s.bits.metaTag === task.tag && 
       (!s.bits.dirHit || !s.bits.s_cmoresp) && s.bits.meta.state =/= INVALID &&
       RegNext(s.bits.w_replResp) && s.bits.w_rprobeacklast && !s.bits.w_releaseack
     )).asUInt


### PR DESCRIPTION
Assertion is required only if  `rxsnp.valid` = 1.
Otherwise x may be generated in vcs.