### PR TITLE
fix(MainPipe): never turn UC to SC on SnpOnce nesting WriteCleanFull

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -373,8 +373,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       )
     }
     when (isSnpOnceX(req_s3.chiOpcode.get)) {
-      // On SnpOnce/SnpOnceFwd nesting WriteCleanFull, turn UD/UC to SC
-      when (req_s3.snpHitReleaseToClean) {
+      // On SnpOnce/SnpOnceFwd nesting WriteCleanFull, turn UD to SC
+      when (req_s3.snpHitReleaseToClean && nestable_meta_s3.dirty) {
         respCacheState := SC
       }
       // On SnpOnce/SnpOnceFwd nesting WriteBack*/WriteEvict*, turn UD to I


### PR DESCRIPTION
* State of WriteCleanFull might be turned to UC on multiple nesting with SnpCleanShared. We only turn UD to SC on SnpOnce nesting WriteCleanFull with state of UD.