### PR TITLE
fix(mshr): convert the default SInt to UInt

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -96,7 +96,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     })
     io.out.valid := ParallelOR(io.idle)
     io.out.bits := ParallelPriorityMux(io.idle.zipWithIndex.map {
-      case (b, i) => (b, (1 << i).U)
+      case (b, i) => (b, (1.U(mshrsAll.W) << i))
     })
   }
 


### PR DESCRIPTION
1 is a 32-bit signed int by default, and the original coding will cause a negative int when mshrall becomes large.