### PR TITLE
fix(MSHR): fix inconsistency for MemAttr of retry request

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -412,7 +412,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     )
     oa.memAttr := MemAttr(
       cacheable = true.B,
-      allocate = !(release_valid2 && isEvict),
+      allocate = !release_valid2 || !isEvict && !cmo_cbo,
       device = false.B,
       ewa = true.B
     )


### PR DESCRIPTION
Currently all write transactions initiated by CBO have the Allocate bit in MemAttr set to zero. However the retry logics do not account for this, resulting in inconsistency of MemAttr between the retry request and the original request.