### PR TITLE
fix(CoupledL2): supplement tagErr handling

### DIFF
--- a/src/main/scala/coupledL2/GrantBuffer.scala
+++ b/src/main/scala/coupledL2/GrantBuffer.scala
@@ -92,7 +92,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
     d.sink := grant_id
     d.denied := task.denied
     d.data := data
-    d.corrupt := task.corrupt
+    d.corrupt := task.corrupt || task.denied
     d.echo.lift(IsKeywordKey).foreach(_ := false.B)
     d
   }
@@ -137,7 +137,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   mergeAtask.bufIdx := io.d_task.bits.task.bufIdx
   mergeAtask.needProbeAckData := io.d_task.bits.task.needProbeAckData
   mergeAtask.denied := io.d_task.bits.task.denied
-  mergeAtask.corrupt := io.d_task.bits.task.corrupt
+  mergeAtask.corrupt := io.d_task.bits.task.corrupt || io.d_task.bits.task.denied
   mergeAtask.mshrTask := io.d_task.bits.task.mshrTask
   mergeAtask.mshrId := io.d_task.bits.task.mshrId
   mergeAtask.aliasTask.foreach(_ := io.d_task.bits.task.aliasTask.getOrElse(0.U))

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -192,7 +192,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       traceTag := rxrsp.bits.traceTag
     }
     when (rxrsp.bits.opcode === CompDBIDResp || rxrsp.bits.opcode === Comp) {
-      denied := denied || rxrsp.bits.respErr === RespErrEncodings.NDERR
+      denied := denied || rxrsp.bits.respErr === RespErrEncodings.NDERR || rxrsp.bits.respErr === RespErrEncodings.DERR
       // TODO: d_corrupt is reserved and must be 0 in TileLink
     }
     when (rxrsp.bits.opcode === RetryAck) {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -596,6 +596,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cbwrdata.mergeA := false.B
     mp_cbwrdata.aMergeTask := 0.U.asTypeOf(new MergeTaskBundle)
 
+    mp_cbwrdata.denied := denied
+    mp_cbwrdata.corrupt := corrupt
+
     // CHI
     mp_cbwrdata.tgtID.get := tgtid_wcompack
     mp_cbwrdata.srcID.get := 0.U
@@ -792,7 +795,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       accessed = req_acquire || req_get
     )
     mp_grant.metaWen := !cmo_cbo && !denied
-    mp_grant.tagWen := !cmo_cbo && !dirResult.hit
+    mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !denied
     mp_grant.dsWen := (gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))) && !denied
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -268,7 +268,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     */
   // whether L2 should do forwarding or not
   val expectFwd = isSnpXFwd(req_s3.chiOpcode.get)
-  val canFwd = nestable_dirResult_s3.hit
+  val canFwd = nestable_dirResult_s3.hit && !(nestable_dirResult_s3.meta.tagErr || nestable_dirResult_s3.error)
   val doFwd = expectFwd && canFwd
   val need_pprobe_s3_b_snpStable = req_s3.fromB && (
     isSnpOnceX(req_s3.chiOpcode.get) || isSnpQuery(req_s3.chiOpcode.get) || isSnpStashX(req_s3.chiOpcode.get)

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -216,6 +216,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   val tagError_s3               = io.dirResp_s3.error || meta_s3.tagErr
   val dataError_s3              = meta_s3.dataErr
+  val l2TagError_s3             = io.dirResp_s3.error
   val l2Error_s3                = io.dirResp_s3.error || mshr_req_s3 && req_s3.dataCheckErr.getOrElse(false.B)
 
   val mshr_refill_s3 = mshr_accessackdata_s3 || mshr_hintack_s3 || mshr_grant_s3 // needs refill to L2 DS
@@ -544,7 +545,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val metaW_s3_a = MetaEntry(
     dirty = meta_s3.dirty,
     state = Mux(req_needT_s3 || sink_resp_s3_a_promoteT, TRUNK, meta_s3.state),
-    clients = Fill(clientBits, true.B),
+    clients = Fill(clientBits, Mux(l2TagError_s3, false.B, true.B)),
     alias = Some(metaW_s3_a_alias),
     accessed = true.B,
     tagErr = meta_s3.tagErr,


### PR DESCRIPTION
* For NDERR from L3, L2 should not write tag to dir 
in MSHR(mp_grant)
* For denied/corrupt from L1, L2 should update respErr
information if nested in MSHR(mp_cbwrdata)
* For tagErr of L2, L2 should not think that L1 holds 
copy if L1 acquires
* L2 never fwd when tagErr
* For TL-D, always report corrupt if denied is high
* For MMIO, if comp(Write Resp) has DERR, report it as
denied to upstream(corrupt not supported)