### PR TITLE
area(CoupledL2): set data SRAM's dataSplit = 8

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -74,11 +74,18 @@ trait HasCoupledL2Parameters {
   def mmioBridgeSize = cacheParams.mmioBridgeSize
 
   // ECC
+  // tag(data)BankSplit refers to tag(data) splits before ECC encode
+  // tag(data)SRAMSplit refers to tag(data) splits of tag(data)Array SRAM
+  // *NOTICE*
+  // tag width = 31, requires padding when split
+  // encDataBank width = 137(bakSplit = 4), requires padding when extra SRAM split
   def enableECC = cacheParams.enableTagECC || cacheParams.enableDataECC
   def enableTagECC = cacheParams.enableTagECC
-  def tagBankSpilt = 1
-  def dataBankSplit = 4 // SRAM dataSplit = 4
-  def tagBankBits = tagBits / tagBankSpilt
+  def tagBankSplit = 1
+  def tagSRAMSplit = 2
+  def dataBankSplit = 4
+  def dataSRAMSplit = 8
+  def tagBankBits = tagBits / tagBankSplit
   def encTagBankBits = cacheParams.tagCode.width(tagBankBits)
   def eccTagBankBits = encTagBankBits - tagBankBits
   def enableDataECC = cacheParams.enableDataECC
@@ -86,6 +93,7 @@ trait HasCoupledL2Parameters {
   def bankWords = blockBits / wordBits / dataBankSplit
   def dataBankBits = wordBits * bankWords
   def encBankBits = cacheParams.dataCode.width(dataBankBits)
+  def encDataPadBits = 4
 
   // Prefetch
   def prefetchers = cacheParams.prefetch

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -77,23 +77,25 @@ trait HasCoupledL2Parameters {
   // tag(data)BankSplit refers to tag(data) splits before ECC encode
   // tag(data)SRAMSplit refers to tag(data) splits of tag(data)Array SRAM
   // *NOTICE*
-  // tag width = 31, requires padding when split
+  // tag width = 31(1 MB L2), requires padding when split
+  // currently, not split tag if SRAM's split requirement cannot meet(L2 size changes)
   // encDataBank width = 137(bakSplit = 4), requires padding when extra SRAM split
   def enableECC = cacheParams.enableTagECC || cacheParams.enableDataECC
   def enableTagECC = cacheParams.enableTagECC
   def tagBankSplit = 1
   def tagSRAMSplit = 2
-  def dataBankSplit = 4
-  def dataSRAMSplit = 8
   def tagBankBits = tagBits / tagBankSplit
   def encTagBankBits = cacheParams.tagCode.width(tagBankBits)
+  def enableTagSRAMSplit = encTagBankBits % (tagSRAMSplit / tagBankSplit) == 0
   def eccTagBankBits = encTagBankBits - tagBankBits
   def enableDataECC = cacheParams.enableDataECC
+  def dataBankSplit = 4
+  def dataSRAMSplit = 8
   def wordBits = 64
   def bankWords = blockBits / wordBits / dataBankSplit
   def dataBankBits = wordBits * bankWords
   def encBankBits = cacheParams.dataCode.width(dataBankBits)
-  def encDataPadBits = 4
+  def encDataPadBits = 4 // recaculate if any split changes
 
   // Prefetch
   def prefetchers = cacheParams.prefetch

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -40,7 +40,7 @@ class DSBlock(implicit p: Parameters) extends L2Bundle {
 
 class DSECCBankBlock(implicit p: Parameters) extends L2Bundle {
   val data = if (enableDataECC) {
-    UInt((encBankBits * dataBankSplit).W)
+    UInt((encDataPadBits + encBankBits * dataBankSplit).W)
   } else {
     UInt((dataBankBits * dataBankSplit).W)
   }
@@ -70,7 +70,7 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     gen = new DSECCBankBlock,
     set = blocks,
     way = 1,
-    dataSplit = 4,
+    dataSplit = dataSRAMSplit,
     singlePort = true,
     readMCP2 = true,
     hasMbist = p(L2ParamKey).hasMbist,
@@ -86,8 +86,8 @@ class DataStorage(implicit p: Parameters) extends L2Module {
 
   val arrayWrite = Wire(new DSECCBankBlock)
   val arrayWriteData = if (enableDataECC) {
-    Cat(VecInit(Seq.tabulate(dataBankSplit)(i =>
-      io.wdata.data(dataBankBits * (i + 1) - 1, dataBankBits * i))).map(data => cacheParams.dataCode.encode(data)))
+    Cat(0.U(encDataPadBits.W), Cat(VecInit(Seq.tabulate(dataBankSplit)(i =>
+      io.wdata.data(dataBankBits * (i + 1) - 1, dataBankBits * i))).map(data => cacheParams.dataCode.encode(data))))
   } else {
     io.wdata.data
   }

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -147,7 +147,11 @@ class Directory(implicit p: Parameters) extends L2Module {
       set = sets,
       way = ways,
       waySplit = 2,
-      dataSplit = tagSRAMSplit,
+      dataSplit = if (enableTagSRAMSplit) {
+        tagSRAMSplit
+      } else {
+        1
+      },
       singlePort = true,
       readMCP2 = false,
       hasMbist = mbist,


### PR DESCRIPTION
* Set data SRAM(`dataArray` in `DataStorage`) dataSplit = 8.
   Previously the dataSplit = 4 and encDataBankBits = 137,
   due to area demand, the `dataArray` SRAM bankBits should
   be 69. Therefore, after ECC encode, the data need further
   split = 2, and add 0 padding(4 bits) each cache line.
* Avoid tag split when tag SRAM's `dataSplit` requirement cannot
   be met. This occurs when L2 size changes or `dataSplit` changes
   or address width.
* Parameterize Split of tag and data.