### PR TITLE
fix(workflow): remove deprecated cache step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,6 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
 
-      - name: Cache
-        id: cache
-        uses: coursier/cache-action@v5
-
       - name: Setup Mill
         uses: jodersky/setup-mill@v0.2.3
         with:


### PR DESCRIPTION
Old caching APIs were no longer in service due to:
- https://github.com/actions/cache/discussions/1510

We just simply removed cache steps in CI workflow because it never worked as expectation.