### PR TITLE
fix(LinkLayer): deactive tx linkactive when exit coherency

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -320,7 +320,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   val exitco = io.exitco.getOrElse(false.B)
   io.out.syscoreq := !exitco
 
-  io.out.txsactive := !exitco
+  io.out.txsactive := !io.out.syscoreq & ~io.out.syscoack
   io.out.tx.linkactivereq := RegNext(true.B, init = false.B)
   io.out.rx.linkactiveack := RegNext(
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -318,14 +318,16 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
 
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
-  io.out.syscoreq := !exitco
+  val exitcoDone = !io.out.syscoreq & !io.out.syscoack
 
-  io.out.txsactive := !io.out.syscoreq & ~io.out.syscoack
-  io.out.tx.linkactivereq := RegNext(true.B, init = false.B)
+  io.out.tx.linkactivereq := RegNext(!exitco, init = false.B)
   io.out.rx.linkactiveack := RegNext(
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
     init = false.B
   )
+
+  io.out.syscoreq := RegNext(!exitco, init = false.B)
+  io.out.txsactive := RegNext(!exitcoDone, init = false.B)
 
   val retryAckCnt = RegInit(0.U(64.W))
   val pCrdGrantCnt = RegInit(0.U(64.W))

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -316,15 +316,16 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   LCredit2Decoupled(io.out.rx.rsp, io.in.rx.rsp, LinkState(rxState), rxrspDeact, Some("rxrsp"))
   LCredit2Decoupled(io.out.rx.dat, io.in.rx.dat, LinkState(rxState), rxdatDeact, Some("rxdat"))
 
-  io.out.txsactive := true.B
+  //exit coherecy + deactive tx/rx when l2 flush done
+  val exitco = io.exitco.getOrElse(false.B)
+  io.out.syscoreq := !exitco
+
+  io.out.txsactive := !exitco
   io.out.tx.linkactivereq := RegNext(true.B, init = false.B)
   io.out.rx.linkactiveack := RegNext(
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
     init = false.B
   )
-  //exit coherecy + deactive tx/rx when l2 flush done
-  val exitco = io.exitco.getOrElse(false.B)
-  io.out.syscoreq := !exitco
 
   val retryAckCnt = RegInit(0.U(64.W))
   val pCrdGrantCnt = RegInit(0.U(64.W))


### PR DESCRIPTION
By following steps, it can be ensured the process of exit coherency and stop linklayer
a. start exit coherency by syscoreq
b. confirm exiting Coherency completion by syscoack
c. Deassert txsactivereq and comfirm by txsactiveack
d. rxactivereq will be triggered by ICN
e. return L-credit and assert rxactiveack
