### PR TITLE
fix(TL2CHICoupledL2): fix txrsp and txdat arbiter to RoundRobin

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -137,11 +137,11 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
 
         // TXRSP
         val txrsp = Wire(DecoupledIO(new CHIRSP))
-        arb(slices.map(_.io.out.tx.rsp), txrsp, Some("txrsp"))
+        fastArb(slices.map(_.io.out.tx.rsp), txrsp, Some("txrsp"))
 
         // TXDAT
         val txdat = Wire(DecoupledIO(new CHIDAT))
-        arb(slices.map(_.io.out.tx.dat) :+ mmio.io.tx.dat, txdat, Some("txdat"))
+        fastArb(slices.map(_.io.out.tx.dat) :+ mmio.io.tx.dat, txdat, Some("txdat"))
 
         // RXSNP
         val rxsnp = Wire(DecoupledIO(new CHISNP))


### PR DESCRIPTION
The issue is that the txdat channel's arbiter, when handling a large number of requests, from 4 slices, is unable to respond slice#3 in a timely manner due to the limitations of the fixed-priority scheduling algorithm, considering slice#3 always has the lowest priority, which leads to the commit timeout.