### PR TITLE
fix(MSHR): deassert EWA for CMO transactions

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -414,7 +414,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       cacheable = true.B,
       allocate = !release_valid2 || !isEvict && !cmo_cbo,
       device = false.B,
-      ewa = true.B
+      ewa = !cmo_cbo
     )
     oa.snpAttr := true.B
     oa.lpIDWithPadding := 0.U


### PR DESCRIPTION
* To meet ISA specification, CMO instructions should only be returned after the consequence was visible to all **non-coherent** agents, which might be out of the CHI domain (e.g. DMAs on crossbars near to memory controller).