### PR TITLE
fix(MSHR): EWA always asserts on cacheable (revert #417)

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -414,7 +414,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       cacheable = true.B,
       allocate = !release_valid2 || !isEvict && !cmo_cbo,
       device = false.B,
-      ewa = !cmo_cbo
+      ewa = true.B
     )
     oa.snpAttr := true.B
     oa.lpIDWithPadding := 0.U


### PR DESCRIPTION
* To meet the specification of CHI, EWA must always be asserted on cacheable addresses. There is no Cacheable Non-bufferable memory type from CPU by definition of ARM. And the only choice for CPU interfaces of CHI was to meet the specification, no violation.

* In ISA specification of RISC-V, the CMO order and observability was required to be guaranteed for non-coherent agents, which was impossible for CHI interface scenario. This ridiculous requirement could only be and must be worked-around on NoC level.