### PR TITLE
fix(Linklayer): fix txsactive asserted before syscoreq after reset

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -348,7 +348,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
 
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
-  val exitcoDone = !io.out.syscoreq & !io.out.syscoack
+  val exitcoDone = !io.out.syscoreq & !io.out.syscoack & io.out.txsactive & txState === LinkStates.STOP
 
   io.out.tx.linkactivereq := RegNext(!exitco, init = false.B)
   io.out.rx.linkactiveack := RegNext(


### PR DESCRIPTION
1. fix syscoreq assert before txsactive asserted when reset is de-asserted.
2. de-asserted txsactive after TX is in TxStop state according to chi protocol 13.7.4