### PR TITLE
fix(LinkLayer): fix linkactive time when power down

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -350,7 +350,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   val exitco = io.exitco.getOrElse(false.B)
   val exitcoDone = !io.out.syscoreq & !io.out.syscoack
 
-  io.out.tx.linkactivereq := RegNext(!exitco, init = false.B)
+  io.out.tx.linkactivereq := RegNext(!exitcoDone, init = false.B)
   io.out.rx.linkactiveack := RegNext(
     next = RegNext(io.out.rx.linkactivereq) || !rxDeact,
     init = false.B


### PR DESCRIPTION
when RN want to exit coherency (syscoreq=0), linkactive should NOT be deasserted before syscoack=0 indicating there is pending snoop on the way, so tx linkactive should keep active until syscoack==0