### PR TITLE
fix(Common, MSHR, MMIOBridge): reserve max QoS for real-time devices

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -148,7 +148,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
 
   def toCHIREQBundle(): CHIREQ = {
     val req = WireInit(0.U.asTypeOf(new CHIREQ()))
-    req.qos := Fill(QOS_WIDTH, 1.U(1.W)) // TODO
+    req.qos := Fill(QOS_WIDTH, 1.U(1.W)) - 1.U // TODO
     req.tgtID := tgtID.getOrElse(0.U)
     req.srcID := srcID.getOrElse(0.U)
     req.txnID := txnID.getOrElse(0.U)

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -219,6 +219,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   io.req.ready := no_schedule && no_wait
   txreq.valid := !s_txreq && w_pcrdgrant
   txreq.bits := 0.U.asTypeOf(txreq.bits.cloneType)
+  txreq.bits.qos := Fill(QOS_WIDTH, 1.U(1.W)) - 1.U
   txreq.bits.tgtID := SAM(sam).lookup(txreq.bits.addr)
   txreq.bits.txnID := io.id
   txreq.bits.opcode := ParallelLookUp(req.opcode, Seq(

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -361,7 +361,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val a_task = {
     val oa = io.tasks.txreq.bits
     oa := 0.U.asTypeOf(io.tasks.txreq.bits.cloneType)
-    oa.qos := Fill(QOS_WIDTH, 1.U(1.W)) // TODO
+    oa.qos := Fill(QOS_WIDTH, 1.U(1.W)) - 1.U // TODO
     oa.tgtID := Mux(!state.s_reissue.getOrElse(false.B), srcid_retryack, 0.U)
     oa.srcID := 0.U
     oa.txnID := io.id


### PR DESCRIPTION
* Take ```MAX_QOS - 1``` for all CPU requests.