### PR TITLE
fix(LinkLayer): fix exitcoDone signal right after reset

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -348,7 +348,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
 
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
-  val exitcoDone = !io.out.syscoreq & !io.out.syscoack & io.out.txsactive & txState === LinkStates.STOP
+  val exitcoDone = !io.out.syscoreq & !io.out.syscoack && RegNext(true.B, init = false.B)
 
   io.out.tx.linkactivereq := RegNext(!exitcoDone, init = false.B)
   io.out.rx.linkactiveack := RegNext(

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -348,7 +348,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
 
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
-  val exitcoDone = !io.out.syscoreq & !io.out.syscoack && RegNext(true.B, init = false.B)
+  val exitcoDone = !io.out.syscoreq && !io.out.syscoack && RegNext(true.B, init = false.B)
 
   io.out.tx.linkactivereq := RegNext(!exitcoDone, init = false.B)
   io.out.rx.linkactiveack := RegNext(


### PR DESCRIPTION
This fix try to fix the false active of 'exitcoDone' the cycle after reset release. So as to resolve the CHI protocal 13.7.2: TXSACTIVE must be asserted when SYSCOREQ is high.