### PR TITLE
feat(MMIOBridge): exclude clint range inner xstilewrap to map the new clint ip

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -38,7 +38,7 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
     * MMIO node
     */
   val beuRange = AddressSet(0x38010000, 4096 - 1)
-  val clintRange = AddressSet(0x38000000L, 0x7fff)
+  val clintRange = AddressSet(0x38000000L, 0xBfff)
   val peripheralRange = AddressSet(
     0x0, 0xffffffffffffL
   ).subtract(beuRange).flatMap(_.subtract(clintRange))

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -38,7 +38,7 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
     * MMIO node
     */
   val beuRange = AddressSet(0x38010000, 4096 - 1)
-  val clintRange = AddressSet(0x38000000L, 0xBfff)
+  val clintRange = AddressSet(0x38000000L, 0xFFFF)
   val peripheralRange = AddressSet(
     0x0, 0xffffffffffffL
   ).subtract(beuRange).flatMap(_.subtract(clintRange))

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -38,9 +38,10 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
     * MMIO node
     */
   val beuRange = AddressSet(0x38010000, 4096 - 1)
+  val clintRange = AddressSet(0x38000000L, 0x7fff)
   val peripheralRange = AddressSet(
     0x0, 0xffffffffffffL
-  ).subtract(beuRange)
+  ).subtract(beuRange).flatMap(_.subtract(clintRange))
 
   val mmioNode = TLManagerNode(Seq(TLSlavePortParameters.v1(
     managers = Seq(TLSlaveParameters.v1(


### PR DESCRIPTION
update for new clint. Timer is one component of new clint ,which is integrated inner xstilewrap，so peripheral addrress map need to be updated.