### PR TITLE
fix(MSHR): fix X-state propagation from RefillBuf

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -485,7 +485,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_release.metaWen := false.B
     mp_release.meta := MetaEntry()
     mp_release.tagWen := false.B
-    mp_release.dsWen := true.B // write refillData to DS on refill, write releaseData to DS on CMO
+    // write refillData to DS on refill, write releaseData to DS on CMO
+    // When refillBuf has no valid data, it should be avoided to write data of RefillBuf to DS which is MCP2
+    mp_release.dsWen := !req_acquirePerm
     mp_release.replTask := true.B
     mp_release.cmoTask := cmo_cbo
     mp_release.wayMask := 0.U(cacheParams.ways.W)


### PR DESCRIPTION
For an MSHR entry handling AcquirePerm, the data in the corresponding RefillBuf is invalid. When the MSHR entry performs a replacement, it needs to write data in RefillBuf into DS, and the write enable signal `dsWen` of replacement request is always driven HIGH. This results in writing X-state data into DS. Although this theoretically does not cause bugs, it will trigger assertion in MCP2 check.