### PR TITLE
feat(MMIOBridge): exclude clint range inner xstilewrap to map the new clint ip

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -40,6 +40,7 @@ trait HasCoupledL2Parameters {
   // val tl2tlParams: HasTLL2Parameters = p(L2ParamKey)
   def enableCHI = p(EnableCHI)
   def cacheParams = p(L2ParamKey)
+  def EnableNewClint = cacheParams.EnableNewClint
 
   def XLEN = 64
   def blocks = cacheParams.sets * cacheParams.ways

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -130,6 +130,9 @@ case class L2Param(
   // Enable sram test support
   hasMbist: Boolean = false,
   hasSramCtl: Boolean = false,
+
+  // Enable new clint
+  EnableNewClint: Boolean = false
 ) {
   def toCacheParams: CacheParameters = CacheParameters(
     name = name,

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -38,9 +38,16 @@ class MMIOBridge()(implicit p: Parameters) extends LazyModule
     * MMIO node
     */
   val beuRange = AddressSet(0x38010000, 4096 - 1)
-  val peripheralRange = AddressSet(
-    0x0, 0xffffffffffffL
-  ).subtract(beuRange)
+  val clintRange = AddressSet(0x38000000L, 0xFFFF)
+  val peripheralRange = if (!EnableNewClint) { // clint is interated with periph bus
+    AddressSet(
+      0x0, 0xffffffffffffL
+    ).subtract(beuRange)
+  } else {
+    AddressSet(
+      0x0, 0xffffffffffffL
+    ).subtract(beuRange).flatMap(_.subtract(clintRange))
+  }
 
   val mmioNode = TLManagerNode(Seq(TLSlavePortParameters.v1(
     managers = Seq(TLSlaveParameters.v1(


### PR DESCRIPTION
1. update for new clint. Timer is one component of new clint ,which is integrated inner xstilewrap，so peripheral addrress map need to be updated.
2. add parameter EnableNewClint from socparamter to MMIOBridge, to control the different logic between the new clint and old clint.