### PR TITLE
area(DataStorage): change Data SRAM's split to 4

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -90,7 +90,7 @@ trait HasCoupledL2Parameters {
   def eccTagBankBits = encTagBankBits - tagBankBits
   def enableDataECC = cacheParams.enableDataECC
   def dataBankSplit = 4
-  def dataSRAMSplit = 8
+  def dataSRAMSplit = 4
   def wordBits = 64
   def bankWords = blockBits / wordBits / dataBankSplit
   def dataBankBits = wordBits * bankWords

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -95,7 +95,7 @@ trait HasCoupledL2Parameters {
   def bankWords = blockBits / wordBits / dataBankSplit
   def dataBankBits = wordBits * bankWords
   def encBankBits = cacheParams.dataCode.width(dataBankBits)
-  def encDataPadBits = 4 // recaculate if any split changes
+  def encDataPadBits = 0 // recaculate if any split changes
 
   // Prefetch
   def prefetchers = cacheParams.prefetch


### PR DESCRIPTION
Given the new physical-design backend requirements, 
changing the L2 Data SRAM specification to split = 4 is
more favorable for both timing and area.