### PR TITLE
fix(ClockGate): fix bug that ICG is invalid when disable mbist

### DIFF
--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -75,8 +75,8 @@ class DataStorage(implicit p: Parameters) extends L2Module {
     readMCP2 = true,
     hasMbist = p(L2ParamKey).hasMbist,
     hasSramCtl = p(L2ParamKey).hasSramCtl,
-    extraHold = enableClockGate,
-    withClockGate = enableClockGate
+    extraHold = true,
+    withClockGate = true
   ))
   array.io_en := io.en
   private val mbistPl = MbistPipeline.PlaceMbistPipeline(1, "L2DataStorage", p(L2ParamKey).hasMbist)


### PR DESCRIPTION
After adding DFT, if DFT is not enabled, due to the assignment `a.clock := clock`, it will directly assign the ungated clock to the SRAM that requires MCP2, causing errors. Therefore, for the `!hasMbist` case, additionally gate the clock for the SRAM.

When DFT is enabled, both `wclk` and `rclk` of `mbistCgCtl` are assigned to `cg.out_clock`. Therefore, although there is the assignment `a.clock := clock`, it does not cause errors.

Additionally, clock gate should always be true when enable MCP2. This commit adds the corresponding requirement check for MCP2 SRAM.