### PR TITLE
fix: extend the cmoAll flush block to over full snoop lifetime

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -510,4 +510,5 @@ class IOCMOAll(implicit p: Parameters) extends Bundle {
   val cmoLineDone = Input(Bool())  // during process of cmo flush all, flush 1 CacheLine is done 
   val mshrValid = Input(Bool())    // 1: mshr has entry valid  0: no mshr entry valid
   val cmoAllBlock = Output(Bool()) // 1: in process of cmo flush all  0: not in process of cmo flush all
+  val snpBlockcmo = Output(UInt(2.W)) 
 }

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -510,5 +510,5 @@ class IOCMOAll(implicit p: Parameters) extends Bundle {
   val cmoLineDone = Input(Bool())  // during process of cmo flush all, flush 1 CacheLine is done 
   val mshrValid = Input(Bool())    // 1: mshr has entry valid  0: no mshr entry valid
   val cmoAllBlock = Output(Bool()) // 1: in process of cmo flush all  0: not in process of cmo flush all
-  val snpBlockcmo = Output(UInt(2.W)) 
+  val snpBlockcmo = Input(UInt(2.W)) 
 }

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -204,7 +204,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
       }.otherwise {
         way.foreach { _ := wayVal + 1.U }
       }
-      when (!mshrValid || snpBlockcmo === 0.U) {
+      when (!mshrValid && snpBlockcmo === 0.U) {
         state.foreach { _ := sCMOREQ }
       }.otherwise {
         state.foreach { _ := sWAITMSHR }

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -144,6 +144,32 @@ class SinkA(implicit p: Parameters) extends L2Module {
     io.a.ready := io.task.ready && !cmoAllBlock
   }
 
+  /* Block cmo flush all into pipeline when any snoop is in-flight.
+   A flush (set+way) and a snoop targeting the same address must not
+   proceed concurrently. The hazard window spans the full snoop
+   lifetime: rxsnp queue → S1 → S2 → S3 → MSHR valid → done.
+   
+   We cannot do address matching at flush S1 because tag is not yet known,
+   so we use a conservative existence check: if any snoop exists anywhere
+   in its lifetime, stall the flush at S1.
+   
+   Each term covers one segment of the snoop lifetime:
+   rxsnp_queue_not_empty : snoop waiting in rxsnp queue, not yet in pipeline
+   snoop_s1/s2/s3_valid  : snoop in-flight in mainpipe, MSHR not yet allocated
+   (s1/s2 protected by index match, s3 by index+tag)
+   snoop_mshr_valid      : snoop has allocated MSHR, still processing
+
+   Snoop has higher priority than flush. When flush and snoop arrive at S1
+   in the same cycle, snoop proceeds and flush is stalled. This is safe
+   because snoops are externally-initiated with timeout pressure, while
+   flush is a background operation that can retry without consequence.
+
+   signal mapping as below
+   snpBlockcmo(0): rxsnp_queue_not_empty + snoop_s1
+   snpBlockcmo(1): s2/s3_valid
+   */
+  val snpBlockcmo = io.cmoAll.map(_.snpBlockcmo).getOrElse(0.U(2.W))
+
   /*
    Flush L2 All means search all L2$ VALID cacheLine and RELEASE to Downwords memory:
    -------------------------------------------------------------------------------------------------------
@@ -178,7 +204,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
       }.otherwise {
         way.foreach { _ := wayVal + 1.U }
       }
-      when (mshrValid) {
+      when (!mshrValid || snpBlockcmo === 0.U) {
         state.foreach { _ := sCMOREQ }
       }.otherwise {
         state.foreach { _ := sWAITMSHR }

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -116,6 +116,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /* l2 flush (CMO All) */
     val cmoAllBlock = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
     val cmoLineDone = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
+    val snpBlockcmo = Option.when(cacheParams.enableL2Flush) (Output(Bool()))
   })
 
   require(chiOpt.isDefined)
@@ -989,6 +990,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val cmoLineDrop = task_s3.valid && sinkA_req_s3 && req_s3.opcode === CBOFlush && cmoHitInvalid
   val cmoLineDone = io.cmoAllBlock.getOrElse(false.B) && task_s3.valid && mshr_cmoresp_s3
   io.cmoLineDone.foreach { _ := RegNextN(cmoLineDone || cmoLineDrop, 2, Some(false.B)) }
+  val snpInFlight = task_s3.valid && req_s3.fromB || task_s2.valid && task_s2.bits.fromB
+  io.snpBlockcmo.foreach { _ := snpInFlight }
 
   /* ===== Performance counters ===== */
   // SinkA requests

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -218,9 +218,13 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.mshrValid := VecInit(mshrCtl.io.msInfo.map(m => m.valid)).reduce(_|_)}
   sinkA.io.cmoAll.foreach {cmoAll => cmoAll.l2Flush := io.l2Flush.getOrElse(false.B)}
   mainPipe.io.cmoAllBlock.foreach {_ := sinkA.io.cmoAll.map(_.cmoAllBlock).getOrElse(false.B)}
-
   io.l2FlushDone.foreach {_ := RegNext(sinkA.io.cmoAll.map(_.l2FlushDone).getOrElse(false.B))}
 
+  sinkA.io.cmoAll.foreach {cmoAll =>
+    cmoAll.snpBlockcmo := Cat(
+      mainPipe.io.snpBlockcmo.getOrElse(false.B),    //@ mainpipe s2 + s3
+      rxsnp.io.task.valid)                           //@ rxsnp queue + s1
+  }
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)
   generatePerfEvent()


### PR DESCRIPTION
Bug: Flush not blocked by concurrent snoop before MSHR allocation

Description:
  When a cmoAll flush (set+way) and a snoop targeting the same
  address are processed concurrently, the flush should be blocked at S1
  until the snoop completes. However, the current block condition at flush
  S1 only checks snoop_mshr_valid, leaving the entire pre-MSHR window
  unprotected. A snoop in-flight in the pipeline (S1/S2/S3) or waiting in
  the rxsnp queue does not block the flush, allowing both to proceed
  concurrently through the pipeline.

Root Cause:
  The block condition at flush S1 only covers the snoop MSHR-valid stage.
  The following segments of the snoop lifetime are not checked:
    - snoop waiting in rxsnp queue (tag known, not yet in pipeline)
    - snoop in mainpipe S1/S2/S3 (MSHR not yet allocated)
  Since tag is not available at flush S1, address matching is not feasible
  at that stage; a conservative existence check covering all snoop pipeline
  stages is required.

Trigger Sequence:
  cycle N  : snoop enters S1, flush enters S1 simultaneously
             snoop wins arbitration (higher priority), flush stalled
  cycle N+1: snoop advances to S2, flush re-enters S1
             flush S1 block condition only checks snoop_mshr_valid = 0
             → flush proceeds into pipeline concurrently with snoop in S2
  cycle N+2: flush in S2, snoop in S3, same address, both in-flight
             → coherency violation ERR109_ILLEGAL_REQ_FOR_COHERENCY_INTERFACE_STATE

Fix:
  Extend the flush S1 block condition to cover the full snoop lifetime:
Verify：
  bump L2 XiangShan ci test and Pldm Linux passed 