### PR TITLE
fix(MSHR): denied/corrupt init based on dirResp.hit

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -148,8 +148,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
     pcrdtype := 0.U
     tagErr := io.alloc.bits.dirResult.hit && (io.alloc.bits.dirResult.meta.tagErr || io.alloc.bits.dirResult.error)
-    denied := io.alloc.bits.task.denied
-    corrupt := io.alloc.bits.task.corrupt
+    denied := io.alloc.bits.dirResult.hit && io.alloc.bits.task.denied
+    corrupt := io.alloc.bits.dirResult.hit && io.alloc.bits.task.corrupt
     cbWrDataTraceTag := false.B
 
     retryTimes := 0.U


### PR DESCRIPTION
When allocating a new MSHR, `denied/corrupt` reg should initialize with `io.alloc.bits.task.denied/corrupt` & dir hit.
Otherwise, L2 might wrongly pass denied/corrupt info to L1, because `denied/corrupt` reg is wrongly asserted.