### PR TITLE
fix: move L-Credit Pool into Sink and Decoupled L2 Tx with LCredit

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -103,7 +103,7 @@ case class L2Param(
   // L2 Flush
   enableL2Flush: Boolean = false,
   // AsyncBridge
-  enableCHIAsyncBridge: Option[Boolean] = None,
+  txSourceReady: Boolean = false,
   // Performance analysis
   enablePerf: Boolean = true,
   // RollingDB

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -71,6 +71,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
     val io_chi = IO(new PortIO)
     val io_nodeID = IO(Input(UInt()))
     val io_cpu_halt = Option.when(cacheParams.enableL2Flush) (IO(Input(Bool())))
+    val io_lcrdy = Option.when(cacheParams.txSourceReady) (IO(Input(new LCrdyIn)))
 
     // Check port width
     require(io_chi.tx.rsp.getWidth == io_chi.rx.rsp.getWidth);
@@ -125,6 +126,9 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
       )
     }
 
+    //Coherency enable from Link Layer: when 1 cacheable request can be sent; otherwise they are gated
+    val coEnable = WireInit(false.B)
+
     slices match {
       case slices: Seq[Slice] =>
         // TXREQ
@@ -132,7 +136,15 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         val txreq = Wire(DecoupledIO(new CHIREQ))
         slices.zip(txreq_arb.io.in.init).foreach { case (s, in) => in <> s.io.out.tx.req }
         txreq_arb.io.in.last <> mmio.io.tx.req
-        txreq <> txreq_arb.io.out
+        /* when coEnable is NOT ready: 
+         1. cancel txreq.valid (mmio always pass)
+         2. disable Arbiter out ready to keep the request
+         */
+        val is_mmio = txreq_arb.io.chosen === slices.size.U
+        val req_pass = coEnable || is_mmio
+        txreq.valid := txreq_arb.io.out.valid && req_pass
+        txreq.bits := txreq_arb.io.out.bits
+        txreq_arb.io.out.ready := txreq.ready && req_pass
         txreq.bits.txnID := setSliceID(txreq_arb.io.out.bits.txnID, txreq_arb.io.chosen, mmio.io.tx.req.fire)
 
         // TXRSP
@@ -267,7 +279,8 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         linkMonitor.io.exitco.foreach { _ :=
           Cat(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone.getOrElse(false.B)}).andR && io_cpu_halt.getOrElse(false.B)
         }
-
+        coEnable := linkMonitor.io.coEnable
+        (io_lcrdy, linkMonitor.io.lcrdy).zipped.foreach { case (in, out) => out := in }
         /**
           * performance counters
           */

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -279,7 +279,7 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         linkMonitor.io.exitco.foreach { _ :=
           Cat(slices.zipWithIndex.map { case (s, i) => s.io.l2FlushDone.getOrElse(false.B)}).andR && io_cpu_halt.getOrElse(false.B)
         }
-        coEnable := linkMonitor.io.coEnable
+        coEnable := linkMonitor.io.out.syscoreq && linkMonitor.io.out.syscoack
         (io_lcrdy, linkMonitor.io.lcrdy).zipped.foreach { case (in, out) => out := in }
         /**
           * performance counters

--- a/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
@@ -124,7 +124,9 @@ object ToAsyncBundleWithBuf {
     /*
      1. Shadow Buffer (depth=16, flow mode for low latency)
      */
-    val shadow_buffer = Module(new Queue(Bool(), 16, flow = true, pipe = false))
+    class EmptyBundle extends Bundle {}
+    val shadow_buffer = Module(new Queue(new EmptyBundle, 16, flow = true, pipe = false))
+//    val shadow_buffer = Module(new Queue(UInt(0.W), 16, flow = true, pipe = false))
     if (name.isDefined) { shadow_buffer.suggestName("lcrdvShadowBuffer_" + name.get) }
     shadow_buffer.io.enq.valid := bit
     shadow_buffer.io.enq.bits  := DontCare
@@ -139,7 +141,6 @@ object ToAsyncBundleWithBuf {
     shadow_buffer.io.deq.ready := source.io.enq.ready
 
     source.io.async
-
   }
 
 }

--- a/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
@@ -21,6 +21,7 @@ import chisel3.util._
 import freechips.rocketchip.util.{AsyncQueueParams, AsyncBundle, AsyncQueueSource, AsyncQueueSink}
 import freechips.rocketchip.util.AsyncResetSynchronizerShiftReg
 import org.chipsalliance.cde.config.Parameters
+import coupledL2.L2ParamKey
 
 class AsyncChannelIO[+T <: Data](gen: T, params: AsyncQueueParams = AsyncQueueParams()) extends Bundle {
   val flitpend = Output(Bool())
@@ -50,6 +51,25 @@ class AsyncPortIO(
   val tx = new AsyncDownwardsLinkIO(params)
   val rx = Flipped(new AsyncUpwardsLinkIO(params))
 }
+
+class ChannelWithActive[T <: Data](gen: T) extends Bundle {
+  val channel = new ChannelIO(gen)
+  val active = Bool()
+}
+
+class LCrdyOut extends Bundle {
+  val req = new Bundle { val rdy = Output(Bool())  }
+  val dat = new Bundle { val rdy = Output(Bool())  }
+  val rsp = new Bundle { val rdy = Output(Bool())  }
+  val empty = Output(Bool())
+}
+
+class LCrdyIn extends Bundle {
+  val req = new Bundle { val rdy = Input(Bool())  }
+  val dat = new Bundle { val rdy = Input(Bool())  }
+  val rsp = new Bundle { val rdy = Input(Bool())  }
+  val empty = Input(Bool())
+}
 /*
  * This module enhances the standard async bridge by adding a front-end shadow buffer
  * to decouple local processing from asynchronous latency and provide instant credit
@@ -68,20 +88,21 @@ object ToAsyncBundleWithBuf {
   def channel[T <: Data](
     chn: ChannelIO[T],
     params: AsyncQueueParams = AsyncQueueParams(depth = 4),
-    name: Option[String] = None
-  ): (Data, Bool) = {
+    name: Option[String] = None,
+    thresh: Int = 16
+  ): (Data, Bool, Bool) = {
     /*
      1. Shadow Buffer (depth=16, flow mode for low latency)
      */
-    val shadow_buffer = Module(new Queue(chiselTypeOf(chn.flit), 16, flow = true, pipe = false))
+    val shadow_buffer = Module(new Queue(chiselTypeOf(chn.flit), 32, flow = true, pipe = false))
     if (name.isDefined) { shadow_buffer.suggestName("shadowBuffer_" + name.get) }
     shadow_buffer.io.enq.valid := chn.flitv
     shadow_buffer.io.enq.bits  := chn.flit
     /*
      2. For rx channel (CMN->L2), send out lcrdv right after a flit entering Shadow buffer if has space
      */
-    val deqReady = shadow_buffer.io.deq.ready
-    dontTouch(deqReady)
+    val hasSpace = shadow_buffer.io.count <= thresh.U
+    dontTouch(hasSpace)
     assert(!chn.flitv || shadow_buffer.io.enq.ready, s"${name.getOrElse("ToAsyncBundle")}: Shadow buffer overflow!")
     /*
      3. AsyncQueueSource (depth=4)
@@ -90,8 +111,37 @@ object ToAsyncBundleWithBuf {
     if (name.isDefined) { source.suggestName("asyncQSource_" + name.get) }
     source.io.enq <> shadow_buffer.io.deq
 
-    (source.io.async, deqReady)
+    val empty = shadow_buffer.io.count === 0.U && source.io.async.widx === source.io.async.ridx
+
+    (source.io.async, hasSpace, empty)
   }
+
+  def bitPulse(
+    bit: Bool,
+    params: AsyncQueueParams = AsyncQueueParams(),
+    name: Option[String] = None
+  ) = {
+    /*
+     1. Shadow Buffer (depth=16, flow mode for low latency)
+     */
+    val shadow_buffer = Module(new Queue(Bool(), 16, flow = true, pipe = false))
+    if (name.isDefined) { shadow_buffer.suggestName("lcrdvShadowBuffer_" + name.get) }
+    shadow_buffer.io.enq.valid := bit
+    shadow_buffer.io.enq.bits  := DontCare
+    /*
+     2. AsyncQueueSource (depth =4)
+     */
+    val source = Module(new AsyncQueueSource(UInt(0.W), params))
+    if (name.isDefined) { source.suggestName("asyncQBitSource_" + name.get) }
+    source.io.enq.valid := shadow_buffer.io.deq.valid
+    source.io.enq.bits := DontCare
+
+    shadow_buffer.io.deq.ready := source.io.enq.ready
+
+    source.io.async
+
+  }
+
 }
 object ToAsyncBundle {
   def channel[T <: Data](
@@ -119,19 +169,103 @@ object ToAsyncBundle {
   }
 }
 
-object FromAsyncBundle {
+object FromAsyncBundleWithLCredit {
   def channel(
     async: AsyncBundle[UInt],
     params: AsyncQueueParams = AsyncQueueParams(),
     name: Option[String] = None,
-    lcrdvReady: Option[Bool]= None
+    linkState: Option[LinkState] = None,  // NEW: needed for state-gated credit logic
+    withPowerAck: Boolean = false
+  ): Data = {
+    val gen = chiselTypeOf(async.mem.head)
+    val out = Wire(new ChannelIO(gen))
+    val sink = Module(new AsyncQueueSink(gen, params))
+    if (name.isDefined) { sink.suggestName("asyncQSink_" + name.get) }
+    sink.io.async <> async
+
+    // ---------------------------------------------------------------
+    // L-Credit pool logic (mirrors Decoupled2LCredit)
+    // ---------------------------------------------------------------
+    val lcreditsMax = 15
+    val lcreditPool = RegInit(0.U(log2Up(lcreditsMax + 1).W))
+
+    // Resolve link state: fall back to always-RUN if not provided
+    val state = linkState.map(_.state).getOrElse(LinkStates.RUN)
+    val disableFlit   = state === LinkStates.STOP || state === LinkStates.ACTIVATE
+    val disableLCredit = state === LinkStates.STOP
+
+    // lcrdv comes in from the downstream receiver (input side of ChannelIO)
+    val acceptLCredit = out.lcrdv && !disableLCredit
+
+    // L-Credit return: send a null flit when deactivating and pool is non-empty
+    // but only when there is nothing real to send
+    val returnLCreditValid = !sink.io.deq.valid &&
+                             state === LinkStates.DEACTIVATE &&
+                             lcreditPool =/= 0.U
+
+    // A real flit fires when the sink has data AND we have credit AND link is active
+    val realFlitFire = sink.io.deq.valid && lcreditPool =/= 0.U && !disableFlit
+
+    // Anything that consumes a credit
+    val flitv = realFlitFire || returnLCreditValid
+
+    // Credit pool update (same semantics as Decoupled2LCredit)
+    when(acceptLCredit) {
+      when(!flitv) {
+        lcreditPool := lcreditPool + 1.U
+        assert(lcreditPool + 1.U <= lcreditsMax.U, "L-Credit pool overflow")
+      }
+      // acceptLCredit && flitv => net zero, no register update needed
+    }.otherwise {
+      when(flitv) {
+        lcreditPool := lcreditPool - 1.U
+        assert(lcreditPool =/= 0.U, "L-Credit pool underflow")
+      }
+    }
+
+    // Gate the async-queue dequeue on credit availability
+    sink.io.deq.ready := lcreditPool =/= 0.U && !disableFlit
+
+    // ---------------------------------------------------------------
+    // Drive ChannelIO outputs (registered, matching Decoupled2LCredit)
+    // ---------------------------------------------------------------
+    out.flitpend := RegNext(true.B, init = false.B)   // TODO: tighten if needed
+    out.flitv    := RegNext(flitv,  init = false.B)
+    out.flit     := RegEnable(
+                      Mux(sink.io.deq.valid,
+                          sink.io.deq.bits,
+                          0.U  /* LCrdReturn null flit */),
+                      flitv)
+
+    // lcrdv is an INPUT on ChannelIO at this side; leave undriven from here
+    out.lcrdv    := DontCare
+
+    // ---------------------------------------------------------------
+    // Optional active flag for power-management handshake
+    // ---------------------------------------------------------------
+    if (withPowerAck) {
+      val result = Wire(new ChannelWithActive(gen))
+      result.channel <> out
+      result.active := sink.io.deq.valid || lcreditPool =/= 0.U  // queue not empty OR credits outstanding
+      result
+    } else {
+      out
+    }
+  }
+}
+
+object FromAsyncBundle {
+  def channel(
+    async: AsyncBundle[UInt],
+    params: AsyncQueueParams = AsyncQueueParams(),
+    name: Option[String] = None
   ) = {
     val gen = chiselTypeOf(async.mem.head)
     val out = Wire(new ChannelIO(gen))
     val sink = Module(new AsyncQueueSink(gen, params))
     if (name.isDefined) { sink.suggestName("asyncQSink_" + name.get) }
     sink.io.async <> async
-    sink.io.deq.ready := lcrdvReady.getOrElse(true.B)
+    sink.io.deq.ready := true.B
     out.flitv := sink.io.deq.valid & sink.io.deq.ready
     out.flit := sink.io.deq.bits
     // flitpend and lcrdv are assigned independently
@@ -162,11 +296,17 @@ class CHIAsyncBridgeSource(params: AsyncQueueParams = AsyncQueueParams())(implic
     val enq = Flipped(new PortIO)
     val async = new AsyncPortIO(params)
     val resetFinish = Output(Bool())
+    val lcrdy = new LCrdyOut
   })
 
-  val async_tx_req = ToAsyncBundleWithBuf.channel(io.enq.tx.req, params, Some("txreq_flit"))
-  val async_tx_rsp = ToAsyncBundleWithBuf.channel(io.enq.tx.rsp, params, Some("txrsp_flit"))
-  val async_tx_dat = ToAsyncBundleWithBuf.channel(io.enq.tx.dat, params, Some("txdat_flit"))
+  val async_tx_req = ToAsyncBundleWithBuf.channel(io.enq.tx.req, params, Some("txreq_flit"), 24)
+  val async_tx_rsp = ToAsyncBundleWithBuf.channel(io.enq.tx.rsp, params, Some("txrsp_flit"), 24)
+  val async_tx_dat = ToAsyncBundleWithBuf.channel(io.enq.tx.dat, params, Some("txdat_flit"), 24)
+
+  io.lcrdy.req.rdy := async_tx_req._2
+  io.lcrdy.rsp.rdy := async_tx_rsp._2
+  io.lcrdy.dat.rdy := async_tx_dat._2
+  io.lcrdy.empty := async_tx_req._3 && async_tx_rsp._3 && async_tx_dat._3
 
   io.async.tx.req.flit <> async_tx_req._1
   io.async.tx.rsp.flit <> async_tx_rsp._1
@@ -232,21 +372,36 @@ class CHIAsyncBridgeSink(params: AsyncQueueParams = AsyncQueueParams())(implicit
     val async = Flipped(new AsyncPortIO(params))
     val deq = new PortIO
     val resetFinish = Output(Bool())
+    val powerAck = new Bundle {
+      val QACTIVE = Output(Bool())
+      val QACCEPTn = Output(Bool())
+      val QREQ = Input(Bool())
+    }
   })
+//  val txSourceReady = cacheParams.txSourceReady
 
-  val txreq_lcrdvReady = Wire(Bool())
-  val txrsp_lcrdvReady = Wire(Bool())
-  val txdat_lcrdvReady = Wire(Bool())
-  io.deq.tx.req <> FromAsyncBundle.channel(io.async.tx.req.flit, params, Some("txreq_flit"), Some(txreq_lcrdvReady))
-  io.deq.tx.rsp <> FromAsyncBundle.channel(io.async.tx.rsp.flit, params, Some("txrsp_flit"), Some(txrsp_lcrdvReady))
-  io.deq.tx.dat <> FromAsyncBundle.channel(io.async.tx.dat.flit, params, Some("txdat_flit"), Some(txdat_lcrdvReady))
+  val txState = RegInit(LinkStates.STOP)
+  val rxState = RegInit(LinkStates.STOP)
 
-  io.async.tx.req.lcrdv <> ToAsyncBundle.bitPulse(io.deq.tx.req.lcrdv, params, Some("txreq_lcrdv"))
-  io.async.tx.rsp.lcrdv <> ToAsyncBundle.bitPulse(io.deq.tx.rsp.lcrdv, params, Some("txrsp_lcrdv"))
-  io.async.tx.dat.lcrdv <> ToAsyncBundle.bitPulse(io.deq.tx.dat.lcrdv, params, Some("txdat_lcrdv"))
+  val txreq = FromAsyncBundleWithLCredit.channel(io.async.tx.req.flit, params, Some("txreq_flit"), Some(LinkState(txState)), true).asInstanceOf[ChannelWithActive[UInt]]
+  val txrsp = FromAsyncBundleWithLCredit.channel(io.async.tx.rsp.flit, params, Some("txrsp_flit"), Some(LinkState(txState)), true).asInstanceOf[ChannelWithActive[UInt]]
+  val txdat = FromAsyncBundleWithLCredit.channel(io.async.tx.dat.flit, params, Some("txdat_flit"), Some(LinkState(txState)), true).asInstanceOf[ChannelWithActive[UInt]]
 
-  val async_rx_rsp = ToAsyncBundleWithBuf.channel(io.deq.rx.rsp, params, Some("rxrsp_flit"))
-  val async_rx_dat = ToAsyncBundleWithBuf.channel(io.deq.rx.dat, params, Some("rxdat_flit"))
+  io.deq.tx.req <> txreq.channel
+  io.deq.tx.rsp <> txrsp.channel
+  io.deq.tx.dat <> txdat.channel
+
+  // Add handshake to confirm Sink Tx Queue is completely drained
+  val txActive = txreq.active || txrsp.active || txdat.active
+  io.powerAck.QACTIVE := txActive
+  io.powerAck.QACCEPTn := !(io.powerAck.QREQ && !txActive && txState === LinkStates.STOP)
+
+  io.async.tx.req.lcrdv <> ToAsyncBundleWithBuf.bitPulse(io.deq.tx.req.lcrdv, params, Some("txreq_lcrdv"))
+  io.async.tx.rsp.lcrdv <> ToAsyncBundleWithBuf.bitPulse(io.deq.tx.rsp.lcrdv, params, Some("txrsp_lcrdv"))
+  io.async.tx.dat.lcrdv <> ToAsyncBundleWithBuf.bitPulse(io.deq.tx.dat.lcrdv, params, Some("txdat_lcrdv"))
+
+  val async_rx_rsp = ToAsyncBundleWithBuf.channel(io.deq.rx.rsp, params, Some("rxrsp_flit"), 16)
+  val async_rx_dat = ToAsyncBundleWithBuf.channel(io.deq.rx.dat, params, Some("rxdat_flit"), 16)
   io.async.rx.rsp.flit <> async_rx_rsp._1
   io.async.rx.dat.flit <> async_rx_dat._1
   io.async.rx.snp.flit <> ToAsyncBundle.channel(io.deq.rx.snp, params, Some("rxsnp_flit"))
@@ -294,9 +449,6 @@ class CHIAsyncBridgeSink(params: AsyncQueueParams = AsyncQueueParams())(implicit
   /*
    Duplicate Link Monitor tx/rx state FSM by using deq.rx deq.tx active signals which outuput to DownStream CHI
    */
-  val txState = RegInit(LinkStates.STOP)
-  val rxState = RegInit(LinkStates.STOP)
-
   Seq(txState, rxState).zip(MixedVecInit(Seq(io.deq.tx, io.deq.rx))).foreach { case (state, link) =>
     state := MuxLookup(Cat(link.linkactivereq, link.linkactiveack), LinkStates.STOP)(Seq(
       Cat(true.B, false.B) -> LinkStates.ACTIVATE,
@@ -308,8 +460,8 @@ class CHIAsyncBridgeSink(params: AsyncQueueParams = AsyncQueueParams())(implicit
 
   /*
    For rx channel, add l-credit manager module to generate lcrdv inside bridge
-   a. Try to use io.deq.rx as LCredit interface to output lcrdv right after rx flit received.
-   b. Try to generate io.deq.rx.dat.lcrdv and io.deq.rx.rsp.lcrdv as instant credit return
+   a. Try to use io.deq.rx as LCredit i/f entering LCredit2Decoupled to generate lcrdv of io.deq.rx.dat and io.deq.rx.rsp
+   b. Try to generate instant credit return if Shadow buffer has Space(async_rx_rsp._2 indicate space > 16)
    c. rxsnp is not in this practice and still use lcrdv generated in CoupledL2 since snoop may be unpredictablely blocked
    */
   val rxrspDeact, rxdatDeact = Wire(Bool())
@@ -318,25 +470,6 @@ class CHIAsyncBridgeSink(params: AsyncQueueParams = AsyncQueueParams())(implicit
   rxin.rx.dat.ready := async_rx_dat._2
   LCredit2Decoupled(io.deq.rx.rsp, rxin.rx.rsp, LinkState(rxState), rxrspDeact, Some("rxrsp"), 15, false)
   LCredit2Decoupled(io.deq.rx.dat, rxin.rx.dat, LinkState(rxState), rxdatDeact, Some("rxdat"), 15, false)
-  /*
-   For tx channel, add l-credit manager module to generate 'ready' to block tx flit to DownStream CHI
-   a. The maximum number of L-Credits in tx channel is 4 inside bridge
-   b. Use L-Credits number more than 4 in CoupledL2 to cover lcrdv sync delay from DownStream CHI to CoupledL2
-   */
-  val txin = WireInit(0.U asTypeOf(Flipped(new DecoupledPortIO()))) //fake Decoupled IO to provide flitv
-  val txout = WireInit(0.U asTypeOf(new PortIO))//fake LCredit IO to provide lcrdv
-  txout.tx.req.lcrdv := io.deq.tx.req.lcrdv
-  txout.tx.rsp.lcrdv := io.deq.tx.rsp.lcrdv
-  txout.tx.dat.lcrdv := io.deq.tx.dat.lcrdv
-  txin.tx.req.valid := io.deq.tx.req.flitv
-  txin.tx.rsp.valid := io.deq.tx.rsp.flitv
-  txin.tx.dat.valid := io.deq.tx.dat.flitv
-  Decoupled2LCredit(txin.tx.req, txout.tx.req, LinkState(txState), Some("txreq"))
-  Decoupled2LCredit(txin.tx.rsp, txout.tx.rsp, LinkState(txState), Some("txrsp"))
-  Decoupled2LCredit(txin.tx.dat, txout.tx.dat, LinkState(txState), Some("txdat"))
-  txreq_lcrdvReady := txin.tx.req.ready
-  txrsp_lcrdvReady := txin.tx.rsp.ready
-  txdat_lcrdvReady := txin.tx.dat.ready
 
   dontTouch(io)
 }

--- a/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/AsyncBridge.scala
@@ -126,7 +126,6 @@ object ToAsyncBundleWithBuf {
      */
     class EmptyBundle extends Bundle {}
     val shadow_buffer = Module(new Queue(new EmptyBundle, 16, flow = true, pipe = false))
-//    val shadow_buffer = Module(new Queue(UInt(0.W), 16, flow = true, pipe = false))
     if (name.isDefined) { shadow_buffer.suggestName("lcrdvShadowBuffer_" + name.get) }
     shadow_buffer.io.enq.valid := bit
     shadow_buffer.io.enq.bits  := DontCare

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config.Parameters
 import utility._
 import coupledL2.L2Module
 import coupledL2.HasCoupledL2Parameters
+import coupledL2.tl2chi.LCrdyIn
 
 class ChannelIO[+T <: Data](gen: T) extends Bundle {
   // Flit Pending. Early indication that a flit might be transmitted in the following cycle
@@ -254,11 +255,7 @@ object LCredit2Decoupled {
     reclaimLCredit := mod.io.reclaimLCredit
   }
 }
-
-class Decoupled2LCredit[T <: Bundle](
-  gen: T,
-  overlcreditNum: Option[Int] = None,
-)(implicit val p: Parameters) extends Module with HasCoupledL2Parameters {
+class Decoupled2LCredit[T <: Bundle](gen: T) extends Module {
   val io = IO(new Bundle() {
     val in = Flipped(DecoupledIO(gen.cloneType))
     val out = ChannelIO(gen.cloneType)
@@ -274,18 +271,15 @@ class Decoupled2LCredit[T <: Bundle](
 
   // The maximum number of L-Credits that a receiver can provide is 15.
   val lcreditsMax = 15
-  val enableCHIAsync = cacheParams.enableCHIAsyncBridge.getOrElse(false)
-  val overlcreditVal = if(enableCHIAsync) overlcreditNum.getOrElse(0) else 0 
-  val lcreditsMaxAll = lcreditsMax + overlcreditVal
-  val lcreditPool = RegInit(overlcreditVal.U(log2Up(lcreditsMaxAll+1).W))
+  val lcreditPool = RegInit(0.U(log2Up(lcreditsMax).W))
 
-  val returnLCreditValid = !io.in.valid && state === LinkStates.DEACTIVATE && lcreditPool =/= overlcreditVal.U
+  val returnLCreditValid = !io.in.valid && state === LinkStates.DEACTIVATE && lcreditPool =/= 0.U
   val flitv = io.in.fire || returnLCreditValid
 
   when (acceptLCredit) {
     when (!flitv) {
       lcreditPool := lcreditPool + 1.U
-      assert(lcreditPool < lcreditsMaxAll.U, "L-Credit pool overflow")
+      assert(lcreditPool + 1.U =/= 0.U, "L-Credit pool overflow")
     }
   }.otherwise {
     when (flitv) {
@@ -299,11 +293,6 @@ class Decoupled2LCredit[T <: Bundle](
   out.flitpend := RegNext(true.B, init = false.B) // TODO
   out.flitv := RegNext(flitv, init = false.B)
   out.flit := RegEnable(Mux(io.in.valid, Cat(io.in.bits.getElements.map(_.asUInt)), 0.U /* LCrdReturn */), flitv)
-
-  /**
-    * performance counters
-    */
-  XSPerfAccumulate("lcrd_received", acceptLCredit)
 }
 
 object Decoupled2LCredit {
@@ -311,10 +300,9 @@ object Decoupled2LCredit {
     left: DecoupledIO[T],
     right: ChannelIO[T],
     state: LinkState,
-    suggestName: Option[String] = None,
-    overlcreditNum: Option[Int] = None
-  )(implicit p: Parameters): Unit = {
-    val mod = Module(new Decoupled2LCredit(left.bits.cloneType, overlcreditNum))
+    suggestName: Option[String] = None
+  ): Unit = {
+    val mod = Module(new Decoupled2LCredit(left.bits.cloneType))
     suggestName.foreach(name => mod.suggestName(s"Decoupled2LCredit_${name}"))
     
     mod.io.in <> left
@@ -323,12 +311,58 @@ object Decoupled2LCredit {
   }
 }
 
+class Decoupled2Source[T <: Bundle](gen: T) extends Module {
+  val io = IO(new Bundle() {
+    val in = Flipped(DecoupledIO(gen.cloneType))
+    val out = ChannelIO(gen.cloneType)
+    val state = Input(new LinkState())
+    val sourceReady = Input(Bool())
+  })
+
+  val out = Wire(io.out.cloneType)
+
+  val state = io.state.state
+  val disableFlit = state === LinkStates.STOP || state === LinkStates.ACTIVATE
+
+  val flitv = WireInit(false.B)
+  val sourceReady_r = RegNext(io.sourceReady, init = true.B) //add register to safe timing
+  flitv := io.in.valid && sourceReady_r && !disableFlit
+
+  io.in.ready := sourceReady_r && !disableFlit
+
+  io.out <> out
+  out.flitpend := RegNext(true.B, init = false.B) // TODO
+  out.flitv := RegNext(flitv, init = false.B)
+  out.flit := RegEnable(Cat(io.in.bits.getElements.map(_.asUInt)), flitv)
+
+}
+
+object Decoupled2Source {
+  def apply[T <: Bundle](
+    left: DecoupledIO[T],
+    right: ChannelIO[T],
+    state: LinkState,
+    sourceReady: Bool,
+    suggestName: Option[String] = None
+  )(implicit p: Parameters): Unit = {
+    val mod = Module(new Decoupled2Source(left.bits.cloneType))
+    suggestName.foreach(name => mod.suggestName(s"Decoupled2Source_${name}"))
+    
+    mod.io.in <> left
+    right <> mod.io.out
+    mod.io.state := state
+    mod.io.sourceReady := sourceReady
+  }
+}
+
 class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   val io = IO(new Bundle() {
     val in = Flipped(new DecoupledPortIO())
     val out = new PortIO
     val nodeID = Input(UInt(NODEID_WIDTH.W))
+    val coEnable = Output(Bool())
     val exitco = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
+    val lcrdy = Option.when(cacheParams.txSourceReady) (Input(new LCrdyIn))
   })
   // val s_stop :: s_activate :: s_run :: s_deactivate :: Nil = Enum(4)
 
@@ -347,9 +381,20 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   /* IO assignment */
   val rxsnpDeact, rxrspDeact, rxdatDeact = Wire(Bool())
   val rxDeact = rxsnpDeact && rxrspDeact && rxdatDeact
-  Decoupled2LCredit(setSrcID(io.in.tx.req, io.nodeID), io.out.tx.req, LinkState(txState), Some("txreq"), Some(8))
-  Decoupled2LCredit(setSrcID(io.in.tx.rsp, io.nodeID), io.out.tx.rsp, LinkState(txState), Some("txrsp"), Some(8))
-  Decoupled2LCredit(setSrcID(io.in.tx.dat, io.nodeID), io.out.tx.dat, LinkState(txState), Some("txdat"), Some(8))
+  val txSourceReady = cacheParams.txSourceReady
+  val ioTXREQReady = io.lcrdy.map(_.req.rdy).getOrElse(true.B)
+  val ioTXRSPReady = io.lcrdy.map(_.rsp.rdy).getOrElse(true.B)
+  val ioTXDATReady = io.lcrdy.map(_.dat.rdy).getOrElse(true.B)
+  if(txSourceReady) {
+    Decoupled2Source(setSrcID(io.in.tx.req, io.nodeID), io.out.tx.req, LinkState(txState), ioTXREQReady, Some("txreqLink"))
+    Decoupled2Source(setSrcID(io.in.tx.rsp, io.nodeID), io.out.tx.rsp, LinkState(txState), ioTXRSPReady, Some("txrspLink"))
+    Decoupled2Source(setSrcID(io.in.tx.dat, io.nodeID), io.out.tx.dat, LinkState(txState), ioTXDATReady, Some("txdatLink"))
+  } else {
+    Decoupled2LCredit(setSrcID(io.in.tx.req, io.nodeID), io.out.tx.req, LinkState(txState), Some("txreqLink"))
+    Decoupled2LCredit(setSrcID(io.in.tx.rsp, io.nodeID), io.out.tx.rsp, LinkState(txState), Some("txrspLink"))
+    Decoupled2LCredit(setSrcID(io.in.tx.dat, io.nodeID), io.out.tx.dat, LinkState(txState), Some("txdatLink"))
+  }
+
   LCredit2Decoupled(io.out.rx.snp, io.in.rx.snp, LinkState(rxState), rxsnpDeact, Some("rxsnp"))
   LCredit2Decoupled(io.out.rx.rsp, io.in.rx.rsp, LinkState(rxState), rxrspDeact, Some("rxrsp"), 15, false)
   LCredit2Decoupled(io.out.rx.dat, io.in.rx.dat, LinkState(rxState), rxdatDeact, Some("rxdat"), 15, false)
@@ -357,6 +402,7 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
   val exitcoDone = !io.out.syscoreq && !io.out.syscoack && RegNext(true.B, init = false.B)
+  io.coEnable := io.out.syscoreq && io.out.syscoack
 
   io.out.tx.linkactivereq := RegNext(!exitcoDone, init = false.B)
   io.out.rx.linkactiveack := RegNext(

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -360,7 +360,6 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
     val in = Flipped(new DecoupledPortIO())
     val out = new PortIO
     val nodeID = Input(UInt(NODEID_WIDTH.W))
-    val coEnable = Output(Bool())
     val exitco = Option.when(cacheParams.enableL2Flush) (Input(Bool()))
     val lcrdy = Option.when(cacheParams.txSourceReady) (Input(new LCrdyIn))
   })
@@ -402,7 +401,6 @@ class LinkMonitor(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   //exit coherecy + deactive tx/rx when l2 flush done
   val exitco = io.exitco.getOrElse(false.B)
   val exitcoDone = !io.out.syscoreq && !io.out.syscoack && RegNext(true.B, init = false.B)
-  io.coEnable := io.out.syscoreq && io.out.syscoack
 
   io.out.tx.linkactivereq := RegNext(!exitcoDone, init = false.B)
   io.out.rx.linkactiveack := RegNext(


### PR DESCRIPTION
Previously, L-Credit pool was managed in LinkMonitor and lcrdv determined ready
was chained through two AsyncQueue (Sink + Source), causing backpressure delay
that stalled MSHRs Tx Channel. The credit pool inside Sink will strictly follow
the CHI LCredit protocol

Currently, L2 Tx path now goes through a single shadow buffer in Source before its
asyncQueue. L2 Tx channel ready is now driven solely by accounting shadow buffer
space only.

Add a parameter "txSourceReady" to Decoupled2Source and LinkMonitor and the IO LCrdy
which allows AsyncBridge to correctly propagate back-pressure while maintaining
copatibility with existing design.



<img width="960" height="463" alt="image" src="https://github.com/user-attachments/assets/3ed7ed97-47e1-4d2e-9c8a-60d5b0b0fd8d" />

