### PR TITLE
fix(MSHR): use L1 data error info when ProbeAckData

### DIFF
--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1115,7 +1115,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.tagErr := c_resp.bits.denied
       meta.dataErr := c_resp.bits.corrupt
       denied := denied || c_resp.bits.denied
-      corrupt := Mux(c_resp.bits.opcode === ProbeAckData, c_resp.bits.corrupt, corrupt || c_resp.bits.corrupt)
+      corrupt := Mux(c_resp.bits.opcode === ProbeAckData || c_resp.bits.opcode === ReleaseData, c_resp.bits.corrupt,
+        corrupt || c_resp.bits.corrupt)
     }
 
     // CMO update release on ProbeAck/ProbeAckData

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1115,7 +1115,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.tagErr := c_resp.bits.denied
       meta.dataErr := c_resp.bits.corrupt
       denied := denied || c_resp.bits.denied
-      corrupt := corrupt || c_resp.bits.corrupt
+      corrupt := Mux(c_resp.bits.opcode === ProbeAckData, c_resp.bits.corrupt, corrupt || c_resp.bits.corrupt)
     }
 
     // CMO update release on ProbeAck/ProbeAckData


### PR DESCRIPTION
A write request: after L1 sends an AcquirePerm to L2 and finishes writing the data, the data has not yet been replaced into L2. Meanwhile, the ICache issues a Get request. At this point, DS in L2 still contains uninitialized garbage data. When allocating the MSHR, corrupt is initialized to 1, but in this situation the data from probeAckData should be treated as the correct source.
Similar situation: L3 snoops L2, L1 Release to L2.