### PR TITLE
fix(Directory): init freeWayMask_s3 as 0 to prevent X propagation

### DIFF
--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -264,7 +264,7 @@ class Directory(implicit p: Parameters) extends L2Module {
     )
   )).reduceTree(_ | _)
 
-  val freeWayMask_s3 = RegEnable(~occWayMask_s2, refillReqValid_s2)
+  val freeWayMask_s3 = RegEnable(~occWayMask_s2, 0.U(ways.W), refillReqValid_s2)
   val refillRetry = !(freeWayMask_s3.orR)
 
   val hitWay = OHToUInt(hitVec)


### PR DESCRIPTION
When L2 receives Snoop broadcast after cache initialization, 
directory uses `finalWay` to generate corresponding ECC `error`.
However, `freeWayMask_s3` is initialized as X, resulting in `error = X`.

This pr initializes`freeWayMask_s3` as 0 to prevent X propagation.