### PR TITLE
fix(SinkA): fix CMOAll FSM snoop interaction and DONE state reset

### DIFF
--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -211,8 +211,13 @@ class SinkA(implicit p: Parameters) extends L2Module {
       }
     }
   }
-  when (stateVal === sWAITMSHR && !mshrValid) {
+  when (stateVal === sWAITMSHR && !mshrValid && snpBlockcmo === 0.U) {
     state.foreach { _ := sCMOREQ }
+  }
+  when (stateVal === sDONE && !l2Flush) {
+    state.foreach { _ := sIDLE }
+    set.foreach { _ := 0.U }
+    way.foreach { _ := 0.U }
   }
 
   // Performance counters


### PR DESCRIPTION
    -  Add snpBlockcmo guard on sWAITMSHR -> sCMOREQ transition.
       Previously, the FSM would re-issue the next CMO request as soon
       as MSHRs were drained, without checking whether an in-flight snoop
       had completed. This allowed a WriteBackFull to be issued after a
       SnpClean had already been responded to, violating CHI protocol
       ordering. Fix by adding snpBlockcmo === 0 condition, consistent
       with the existing guard on the sWAITLINE -> sCMOREQ transition.

    -  Add sIDLE reset on l2Flush deassert from sDONE state.
       After CMOAll completes, the FSM was stuck in sDONE indefinitely.
       Reset to sIDLE and clear set/way counters when l2Flush deasserts,
       allowing the FSM to be reused for subsequent flush operations.