### PR TITLE
fix(MSHR, MainPipe): update error info when nestedwb

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -383,6 +383,9 @@ class NestedWriteback(implicit p: Parameters) extends L2Bundle {
   val b_toB = chiOpt.map(_ => Bool())
   val b_toN = chiOpt.map(_ => Bool())
   val b_toClean = chiOpt.map(_ => Bool())
+
+  val denied = Bool()
+  val corrupt = Bool()
 }
 
 class PrefetchCtrlFromCore extends Bundle {

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -1392,10 +1392,13 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
       releaseDirty := true.B
+      denied := denied || io.nestedwb.denied
+      corrupt := io.nestedwb.corrupt
     }
     when (io.nestedwb.c_set_tip) {
       meta.state := TIP
       meta.clients := Fill(clientBits, false.B)
+      denied := denied || io.nestedwb.denied
     }
     when (io.nestedwb.b_inv_dirty && req.fromA) {
       meta.dirty := false.B

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -688,6 +688,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   /* ======== nested writeback ======== */
   io.nestedwb.set := req_s3.set
   io.nestedwb.tag := req_s3.tag
+  io.nestedwb.denied := req_s3.denied
+  io.nestedwb.corrupt := req_s3.corrupt
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData && task_s3.bits.param === TtoN

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -597,6 +597,8 @@ class MSHR(implicit p: Parameters) extends L2Module {
   when (nestedwb_match) {
     when (io.nestedwb.c_set_dirty) {
       meta.dirty := true.B
+      denied := denied || io.nestedwb.denied
+      corrupt := io.nestedwb.corrupt
     }
   }
   // let nested C write ReleaseData to the MSHRBuffer entry of this MSHR id

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -435,6 +435,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   /* ======== nested & prefetch ======== */
   io.nestedwb.set := req_s3.set
   io.nestedwb.tag := req_s3.tag
+  io.nestedwb.denied := req_s3.denied
+  io.nestedwb.corrupt := req_s3.corrupt
   // This serves as VALID signal
   // c_set_dirty is true iff Release has Data
   io.nestedwb.c_set_dirty := task_s3.valid && task_s3.bits.fromC && task_s3.bits.opcode === ReleaseData


### PR DESCRIPTION
When repl task nests (L1) release, MSHR should release data error information from L1.
Otherwise, data error info might be X if L2 data are X.