### PR TITLE
feat(hpm): add descriptions to L2 HPM events

### DIFF
--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -491,10 +491,11 @@ abstract class CoupledL2Base(implicit p: Parameters) extends LazyModule with Has
         slice
     }
 
-    val perfEvents = Seq(("noEvent", 0.U)) ++ slices.zipWithIndex.map {
-      case (slide, slide_idx) =>
-        slide.getPerfEvents.map{case (str, idx) => ("Slice" + slide_idx.toString + "_" + str, idx)}
-    }.flatten
+    val perfEvents = Seq(
+      ("noEvent", 0.U).withDescription("No event; always contributes zero."),
+    ) ++ slices.zipWithIndex.flatMap { case (slice, sliceIndex) =>
+      slice.getPerfEventInfos.map(event => event.withName(s"Slice${sliceIndex}_${event.name}"))
+    }
     generatePerfEvent()
 
     // ECC error

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -260,11 +260,14 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
   }
 
   val perfEvents = Seq(
-    ("l2_cache_refill", io.resps.rxdat.valid && io.resps.rxdat.respInfo.last),
-    ("l2_cache_rd_refill", io.resps.rxdat.valid && io.resps.rxdat.respInfo.last),
-    ("l2_cache_wr_refill", false.B),
+    ("l2_cache_refill"   , io.resps.rxdat.valid && io.resps.rxdat.respInfo.last)
+      .withDescription("L2 cache-line refill completed from the CHI data channel."),
+    ("l2_cache_rd_refill", io.resps.rxdat.valid && io.resps.rxdat.respInfo.last)
+      .withDescription("L2 read refill completed from the CHI data channel."),
+    ("l2_cache_wr_refill", false.B)
+      .withDescription("L2 write refill completed; unsupported in this implementation."),
     ("l2_cache_long_miss", lmiss.reduce(_ + _))
+      .withDescription("L2 misses completing after more than 200 cycles.")
   )
   generatePerfEvent()
 }
-

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -1151,20 +1151,33 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(
-    ("l2_cache_hit", hit_s3 && req_s3.fromA),
-    ("l2_cache_miss", miss_s3 && req_s3.fromA),
-    ("l2_cache_access", task_s3.valid && (sinkA_req_s3 && !req_prefetch_s3 || sinkC_req_s3)),
-    ("l2_cache_l2wb", task_s3.valid && (mshr_cbWrData_s3 || mshr_snpRespDataX_s3)),
-    ("l2_cache_l1wb", task_s3.valid && sinkC_req_s3 && (req_s3.opcode === ReleaseData)),
-    ("l2_cache_wb_victim", task_s3.valid && mshr_cbWrData_s3),
-    ("l2_cache_wb_cleaning_coh", task_s3.valid && mshr_snpRespDataX_s3),
-    ("l2_cache_prefetch_access", task_s3.valid && sinkA_req_s3 && req_prefetch_s3),
-    ("l2_cache_prefetch_miss", task_s3.valid && sinkA_req_s3 && req_prefetch_s3 && miss_s3),
-    ("l2_cache_access_rd", task_s3.valid && sinkA_req_s3 && !req_prefetch_s3),
-    ("l2_cache_access_wr", task_s3.valid && sinkC_req_s3),
-    ("l2_cache_miss_rd", task_s3.valid && sinkA_req_s3 && !req_prefetch_s3 && miss_s3),
+    ("l2_cache_hit"            , hit_s3 && req_s3.fromA)
+      .withDescription("Upstream TileLink A request that hit in L2."),
+    ("l2_cache_miss"           , miss_s3 && req_s3.fromA)
+      .withDescription("Upstream TileLink A request that missed in L2."),
+    ("l2_cache_access"         , task_s3.valid && (sinkA_req_s3 && !req_prefetch_s3 || sinkC_req_s3))
+      .withDescription("Demand read or write access processed by L2."),
+    ("l2_cache_l2wb"           , task_s3.valid && (mshr_cbWrData_s3 || mshr_snpRespDataX_s3))
+      .withDescription("Cache line written back from L2 to the CHI interconnect."),
+    ("l2_cache_l1wb"           , task_s3.valid && sinkC_req_s3 && (req_s3.opcode === ReleaseData))
+      .withDescription("Dirty cache line written back from L1 to L2."),
+    ("l2_cache_wb_victim"      , task_s3.valid && mshr_cbWrData_s3)
+      .withDescription("L2 victim cache line written back on replacement."),
+    ("l2_cache_wb_cleaning_coh", task_s3.valid && mshr_snpRespDataX_s3)
+      .withDescription("L2 cache line written back while cleaning coherence state."),
+    ("l2_cache_prefetch_access", task_s3.valid && sinkA_req_s3 && req_prefetch_s3)
+      .withDescription("Prefetch access processed by L2."),
+    ("l2_cache_prefetch_miss"  , task_s3.valid && sinkA_req_s3 && req_prefetch_s3 && miss_s3)
+      .withDescription("Prefetch access that missed in L2."),
+    ("l2_cache_access_rd"      , task_s3.valid && sinkA_req_s3 && !req_prefetch_s3)
+      .withDescription("Demand read access processed by L2."),
+    ("l2_cache_access_wr"      , task_s3.valid && sinkC_req_s3)
+      .withDescription("Upstream writeback access processed by L2."),
+    ("l2_cache_miss_rd"        , task_s3.valid && sinkA_req_s3 && !req_prefetch_s3 && miss_s3)
+      .withDescription("Demand read access that missed in L2."),
     //    ("l2_cache_miss_wr", Inclusive L2 always hit),
-    ("l2_cache_inv", task_s3.valid && sinkB_req_s3 && (req_s3.param === toN))
+    ("l2_cache_inv"            , task_s3.valid && sinkB_req_s3 && (req_s3.param === toN))
+      .withDescription("Probe request that invalidates an upstream cache line.")
   )
   generatePerfEvent()
 }

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -227,6 +227,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
       rxsnp.io.task.valid)                           //@ rxsnp queue + s1
   }
   /* ===== Hardware Performance Monitor ===== */
-  val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)
+  val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEventInfos)
   generatePerfEvent()
 }

--- a/src/main/scala/coupledL2/tl2tl/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHRCtl.scala
@@ -246,10 +246,14 @@ class MSHRCtl(implicit p: Parameters) extends L2Module with HasPerfEvents {
   }
 
   val perfEvents = Seq(
-    ("l2_cache_refill", acquireUnit.io.sourceA.fire && acquireUnit.io.task.bits.opcode === AcquireBlock),
-    ("l2_cache_rd_refill", acquireUnit.io.sourceA.fire && acquireUnit.io.task.bits.opcode === AcquireBlock),
-    ("l2_cache_wr_refill", false.B),
+    ("l2_cache_refill"   , acquireUnit.io.sourceA.fire && acquireUnit.io.task.bits.opcode === AcquireBlock)
+      .withDescription("L2 cache-line refill request issued downstream."),
+    ("l2_cache_rd_refill", acquireUnit.io.sourceA.fire && acquireUnit.io.task.bits.opcode === AcquireBlock)
+      .withDescription("L2 read refill request issued downstream."),
+    ("l2_cache_wr_refill", false.B)
+      .withDescription("L2 write refill completed; unsupported in this implementation."),
     ("l2_cache_long_miss", lmiss.reduce(_ + _))
+      .withDescription("L2 misses completing after more than 200 cycles.")
   )
   generatePerfEvent()
 }

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -760,20 +760,33 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
 
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(
-    ("l2_cache_hit", hit_s3 && req_s3.fromA),
-    ("l2_cache_miss", miss_s3 && req_s3.fromA),
-    ("l2_cache_access", task_s3.valid && (sinkA_req_s3 && !req_prefetch_s3 || sinkC_req_s3)),
-    ("l2_cache_l2wb", task_s3.valid && (mshr_releasedata_s3 || mshr_probeackdata_s3)),
-    ("l2_cache_l1wb", task_s3.valid && sinkC_req_s3 && (req_s3.opcode === ReleaseData)),
-    ("l2_cache_wb_victim", task_s3.valid && mshr_releasedata_s3),
-    ("l2_cache_wb_cleaning_coh", task_s3.valid && mshr_probeackdata_s3),
-    ("l2_cache_prefetch_access", task_s3.valid && sinkA_req_s3 && req_prefetch_s3),
-    ("l2_cache_prefetch_miss", task_s3.valid && sinkA_req_s3 && req_prefetch_s3 && miss_s3),
-    ("l2_cache_access_rd", task_s3.valid && sinkA_req_s3 && !req_prefetch_s3),
-    ("l2_cache_access_wr", task_s3.valid && sinkC_req_s3),
-    ("l2_cache_miss_rd", task_s3.valid && sinkA_req_s3 && !req_prefetch_s3 && miss_s3),
+    ("l2_cache_hit"            , hit_s3 && req_s3.fromA)
+      .withDescription("Upstream TileLink A request that hit in L2."),
+    ("l2_cache_miss"           , miss_s3 && req_s3.fromA)
+      .withDescription("Upstream TileLink A request that missed in L2."),
+    ("l2_cache_access"         , task_s3.valid && (sinkA_req_s3 && !req_prefetch_s3 || sinkC_req_s3))
+      .withDescription("Demand read or write access processed by L2."),
+    ("l2_cache_l2wb"           , task_s3.valid && (mshr_releasedata_s3 || mshr_probeackdata_s3))
+      .withDescription("Cache line written back from L2 to downstream memory."),
+    ("l2_cache_l1wb"           , task_s3.valid && sinkC_req_s3 && (req_s3.opcode === ReleaseData))
+      .withDescription("Dirty cache line written back from L1 to L2."),
+    ("l2_cache_wb_victim"      , task_s3.valid && mshr_releasedata_s3)
+      .withDescription("L2 victim cache line written back on replacement."),
+    ("l2_cache_wb_cleaning_coh", task_s3.valid && mshr_probeackdata_s3)
+      .withDescription("L2 cache line written back while cleaning coherence state."),
+    ("l2_cache_prefetch_access", task_s3.valid && sinkA_req_s3 && req_prefetch_s3)
+      .withDescription("Prefetch access processed by L2."),
+    ("l2_cache_prefetch_miss"  , task_s3.valid && sinkA_req_s3 && req_prefetch_s3 && miss_s3)
+      .withDescription("Prefetch access that missed in L2."),
+    ("l2_cache_access_rd"      , task_s3.valid && sinkA_req_s3 && !req_prefetch_s3)
+      .withDescription("Demand read access processed by L2."),
+    ("l2_cache_access_wr"      , task_s3.valid && sinkC_req_s3)
+      .withDescription("Upstream writeback access processed by L2."),
+    ("l2_cache_miss_rd"        , task_s3.valid && sinkA_req_s3 && !req_prefetch_s3 && miss_s3)
+      .withDescription("Demand read access that missed in L2."),
     //    ("l2_cache_miss_wr", Inclusive L2 always hit),
-    ("l2_cache_inv", task_s3.valid && sinkB_req_s3 && (req_s3.param === toN))
+    ("l2_cache_inv"            , task_s3.valid && sinkB_req_s3 && (req_s3.param === toN))
+      .withDescription("Probe request that invalidates an upstream cache line.")
   )
   generatePerfEvent()
 }

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -218,6 +218,6 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   monitor.io.fromMainPipe <> mainPipe.io.toMonitor
 
   /* ===== Hardware Performance Monitor ===== */
-  val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)
+  val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEventInfos)
   generatePerfEvent()
 }


### PR DESCRIPTION
Attach concise descriptions to the TL and CHI L2 event sources and preserve them while slice events are aggregated. Keep the existing per-slice event names and numbering unchanged.